### PR TITLE
Upgrade to .NET Framework 4.8.1 (+ some clean-up)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
   <!-- If it does not, the properties `LsSrcPath`, `LsLibPath`, and `ComponentsPath` must be provided via the command line. -->
   <!-- Example: `dotnet build -p:LsSrcPath=path/to/LiveSplit/src` -->
 
-  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)\..))" />
-  <Import Project="$(MSBuildThisFileDirectory)\props\*.props" />
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)..))" />
+  <Import Project="$(MSBuildThisFileDirectory)props\*.props" />
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
           Condition="Exists('..\Directory.Build.props')" />
 
   <PropertyGroup Label="Project Settings">
-    <TargetFramework>net4.6.1</TargetFramework>
+    <TargetFramework>net4.8.1</TargetFramework>
 
     <Nullable>disable</Nullable>
   </PropertyGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <!-- Imports `Directory.Build.props` from the above directory, if it exists. -->
-  <!-- If it does not, the properties `LsSrcPath`, `LsLibPath`, and `ComponentsDir` must be provided via the command line. -->
+  <!-- If it does not, the properties `LsSrcPath`, `LsLibPath`, and `ComponentsPath` must be provided via the command line. -->
   <!-- Example: `dotnet build -p:LsSrcPath=path/to/LiveSplit/src` -->
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)\..))" />

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,24 +4,7 @@
   <!-- If it does not, the properties `LsSrcPath`, `LsLibPath`, and `ComponentsDir` must be provided via the command line. -->
   <!-- Example: `dotnet build -p:LsSrcPath=path/to/LiveSplit/src` -->
 
-  <Import Project="..\Directory.Build.props"
-          Condition="Exists('..\Directory.Build.props')" />
-
-  <PropertyGroup Label="Project Settings">
-    <TargetFramework>net4.8.1</TargetFramework>
-
-    <Nullable>disable</Nullable>
-  </PropertyGroup>
-
-  <PropertyGroup Label="Common Directories">
-    <RootPath>$(MSBuildThisFileDirectory)</RootPath>
-
-    <SrcPath>$(RootPath)\src</SrcPath>
-    <TestPath>$(RootPath)\test</TestPath>
-  </PropertyGroup>
-
-  <PropertyGroup Label="Output Settings">
-    <UseArtifactsOutput>true</UseArtifactsOutput>
-  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove(Directory.Build.props, $(MSBuildThisFileDirectory)\..))" />
+  <Import Project="$(MSBuildThisFileDirectory)\props\*.props" />
 
 </Project>

--- a/props/LiveSplit.Sound.Paths.props
+++ b/props/LiveSplit.Sound.Paths.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <RootPath>$(MSBuildThisFileDirectory)\..</RootPath>
+    <RootPath>$(MSBuildThisFileDirectory)..</RootPath>
 
     <SrcPath>$(RootPath)\src</SrcPath>
     <TestPath>$(RootPath)\test</TestPath>

--- a/props/LiveSplit.Sound.Paths.props
+++ b/props/LiveSplit.Sound.Paths.props
@@ -1,0 +1,10 @@
+<Project>
+
+  <PropertyGroup>
+    <RootPath>$(MSBuildThisFileDirectory)\..</RootPath>
+
+    <SrcPath>$(RootPath)\src</SrcPath>
+    <TestPath>$(RootPath)\test</TestPath>
+  </PropertyGroup>
+
+</Project>

--- a/props/LiveSplit.Sound.props
+++ b/props/LiveSplit.Sound.props
@@ -1,0 +1,13 @@
+<Project>
+
+  <!-- Project properties. -->
+  <PropertyGroup>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+
+  <!-- Output properties. -->
+  <PropertyGroup>
+    <UseArtifactsOutput>true</UseArtifactsOutput>
+  </PropertyGroup>
+
+</Project>

--- a/src/LiveSplit.Sound/LiveSplit.Sound.csproj
+++ b/src/LiveSplit.Sound/LiveSplit.Sound.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <UseWindowsForms>true</UseWindowsForms>
+    <TargetFramework>net4.8.1</TargetFramework>
 
     <EnableDynamicLoading>true</EnableDynamicLoading>
   </PropertyGroup>


### PR DESCRIPTION
Parent PR: https://github.com/LiveSplit/LiveSplit/pull/2518

### Description

This PR upgrades this component's target framework to .NET Framework 4.8.1, the most recent stable release.

As stated in the parent, this PR also incldues some clean-up. I thought it may be less annoying having to merge just one PR here and on all of the components instead of opening multiple ones. I will revert those additional commits if so desired.
