### PR TITLE
Add `.editorconfig` & apply style rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,368 @@
+root = true
+
+# All files
+[*]
+indent_style             = space
+trim_trailing_whitespace = true
+
+# New line preferences
+end_of_line          = crlf
+insert_final_newline = true
+
+# Xml project files
+[*.{csproj,proj}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets}]
+indent_size = 2
+
+# Other markup files
+[*.{json,xml,yml}]
+indent_size = 2
+
+# Markdown files
+[*.md]
+indent_size              = 2
+trim_trailing_whitespace = false
+
+# C# files
+[*.cs]
+indent_size = 4
+
+
+#### C# Style Rules ####
+[*.cs]
+
+file_header_template = unset
+
+# Uncategorized rules (diagnostics without a property equivalent)
+
+dotnet_diagnostic.IDE0001.severity = suggestion # Simplify name
+dotnet_diagnostic.IDE0002.severity = suggestion # Simplify member access
+dotnet_diagnostic.IDE0004.severity = warning    # Remove unnecessary cast
+dotnet_diagnostic.IDE0005.severity = warning    # Remove unnecessary import
+dotnet_diagnostic.IDE0035.severity = suggestion # Remove unreachable code
+dotnet_diagnostic.IDE0050.severity = warning    # Convert anonymous type to tuple
+dotnet_diagnostic.IDE0051.severity = suggestion # Remove unused private member
+dotnet_diagnostic.IDE0052.severity = suggestion # Remove unread private member
+dotnet_diagnostic.IDE0064.severity = suggestion # Make struct fields writable
+dotnet_diagnostic.IDE0080.severity = warning    # Remove unnecessary suppression operator
+dotnet_diagnostic.IDE0082.severity = warning    # Convert `typeof` to `nameof`
+dotnet_diagnostic.IDE0100.severity = warning    # Remove unnecessary equality operator
+dotnet_diagnostic.IDE0110.severity = suggestion # Remove unnecessary discard
+dotnet_diagnostic.IDE0120.severity = warning    # Simplify LINQ expression
+dotnet_diagnostic.IDE0280.severity = warning    # Use `nameof`
+
+
+#### .NET Coding Conventions ####
+
+# Organize usings
+dotnet_separate_import_directive_groups = true
+dotnet_sort_system_directives_first     = true
+
+# this. and Me. preferences
+dotnet_style_qualification_for_event    = false:warning
+dotnet_style_qualification_for_field    = false:warning
+dotnet_style_qualification_for_method   = false:warning
+dotnet_style_qualification_for_property = false:warning
+
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
+dotnet_style_predefined_type_for_member_access             = true:warning
+
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:warning
+dotnet_style_parentheses_in_other_binary_operators      = always_for_clarity:warning
+dotnet_style_parentheses_in_other_operators             = never_if_unnecessary:warning
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:warning
+
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:warning
+
+# Expression-level preferences
+dotnet_style_coalesce_expression                                 = true:suggestion
+dotnet_style_collection_initializer                              = true:warning
+dotnet_style_explicit_tuple_names                                = true:warning
+dotnet_style_null_propagation                                    = true:suggestion
+dotnet_style_object_initializer                                  = true:warning
+dotnet_style_operator_placement_when_wrapping                    = beginning_of_line
+dotnet_style_prefer_auto_properties                              = true:warning
+dotnet_style_prefer_collection_expression                        = true:suggestion
+dotnet_style_prefer_compound_assignment                          = true:warning
+dotnet_style_prefer_conditional_expression_over_assignment       = true:silent
+dotnet_style_prefer_conditional_expression_over_return           = false:silent
+dotnet_style_prefer_foreach_explicit_cast_in_source              = when_strongly_typed
+dotnet_style_prefer_inferred_anonymous_type_member_names         = false:suggestion
+dotnet_style_prefer_inferred_tuple_names                         = false:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
+dotnet_style_prefer_simplified_boolean_expressions               = true:suggestion
+dotnet_style_prefer_simplified_interpolation                     = true:suggestion
+csharp_style_throw_expression                                    = false:warning
+
+# Field preferences
+dotnet_style_readonly_field = true:warning
+
+# Parameter preferences
+dotnet_code_quality_unused_parameters = all:suggestion
+
+# Suppression preferences
+dotnet_remove_unnecessary_suppression_exclusions = suggestion
+
+# New line preferences
+dotnet_style_allow_multiple_blank_lines_experimental              = false:warning
+dotnet_style_allow_statement_immediately_after_block_experimental = false:warning
+
+
+#### C# Coding Conventions ####
+
+# readonly preferences
+csharp_style_prefer_readonly_struct        = true:warning
+csharp_style_prefer_readonly_struct_member = true:warning
+
+# var preferences
+csharp_style_var_elsewhere             = false:suggestion
+csharp_style_var_for_built_in_types    = false:suggestion
+csharp_style_var_when_type_is_apparent = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_accessors       = when_on_single_line:suggestion
+csharp_style_expression_bodied_constructors    = false:warning
+csharp_style_expression_bodied_indexers        = when_on_single_line:suggestion
+csharp_style_expression_bodied_lambdas         = when_on_single_line:suggestion
+csharp_style_expression_bodied_local_functions = false:warning
+csharp_style_expression_bodied_methods         = false:warning
+csharp_style_expression_bodied_operators       = false:warning
+csharp_style_expression_bodied_properties      = when_on_single_line:suggestion
+
+# Pattern matching preferences
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
+csharp_style_pattern_matching_over_is_with_cast_check = true:warning
+csharp_style_prefer_not_pattern                       = true:warning
+csharp_style_prefer_extended_property_pattern         = true:warning
+csharp_style_prefer_pattern_matching                  = true:suggestion
+csharp_style_prefer_switch_expression                 = true:suggestion
+
+# Null-checking preferences
+csharp_style_conditional_delegate_call = true:suggestion
+
+# Modifier preferences
+csharp_prefer_static_local_function = true:warning
+csharp_preferred_modifier_order     = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:silent
+
+# Code-block preferences
+csharp_prefer_braces                        = true:warning
+csharp_prefer_simple_using_statement        = true:warning
+csharp_style_prefer_method_group_conversion = true:suggestion
+csharp_style_prefer_top_level_statements    = true:suggestion
+
+# Expression-level preferences
+csharp_prefer_simple_default_expression                     = true:warning
+csharp_style_deconstructed_variable_declaration             = true:warning
+csharp_style_implicit_object_creation_when_type_is_apparent = true:warning
+csharp_style_inlined_variable_declaration                   = true:warning
+csharp_style_pattern_local_over_anonymous_function          = true:warning
+csharp_style_prefer_index_operator                          = true:warning
+csharp_style_prefer_local_over_anonymous_function           = true:warning
+csharp_style_prefer_null_check_over_type_check              = true:warning
+csharp_style_prefer_range_operator                          = true:warning
+csharp_style_prefer_tuple_swap                              = true:warning
+csharp_style_prefer_utf8_string_literals                    = true:suggestion
+csharp_style_unused_value_assignment_preference             = discard_variable:none
+csharp_style_unused_value_expression_statement_preference   = discard_variable:none
+
+# 'using' directive preferences
+csharp_using_directive_placement = outside_namespace:warning
+
+
+#### C# Formatting Rules ####
+
+# New line preferences
+csharp_new_line_before_catch                                                      = true
+csharp_new_line_before_else                                                       = true
+csharp_new_line_before_finally                                                    = true
+csharp_new_line_before_members_in_anonymous_types                                 = true
+csharp_new_line_before_members_in_object_initializers                             = true
+csharp_new_line_before_open_brace                                                 = all
+csharp_new_line_between_query_expression_clauses                                  = true
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = false:warning
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental  = false:warning
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = false:warning
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental            = false:warning
+csharp_style_allow_embedded_statements_on_same_line_experimental                  = false:warning
+
+# Indentation preferences
+csharp_indent_block_contents           = true
+csharp_indent_braces                   = false
+csharp_indent_case_contents            = true
+csharp_indent_case_contents_when_block = false
+csharp_indent_labels                   = one_less_than_current
+csharp_indent_switch_labels            = true
+
+# Space preferences
+csharp_space_after_cast                                                  = false
+csharp_space_after_colon_in_inheritance_clause                           = true
+csharp_space_after_comma                                                 = true
+csharp_space_after_dot                                                   = false
+csharp_space_after_keywords_in_control_flow_statements                   = true
+csharp_space_after_semicolon_in_for_statement                            = true
+csharp_space_around_binary_operators                                     = before_and_after
+csharp_space_around_declaration_statements                               = false
+csharp_space_before_colon_in_inheritance_clause                          = true
+csharp_space_before_comma                                                = false
+csharp_space_before_dot                                                  = false
+csharp_space_before_open_square_brackets                                 = false
+csharp_space_before_semicolon_in_for_statement                           = false
+csharp_space_between_empty_square_brackets                               = false
+csharp_space_between_method_call_empty_parameter_list_parentheses        = false
+csharp_space_between_method_call_name_and_opening_parenthesis            = false
+csharp_space_between_method_call_parameter_list_parentheses              = false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_declaration_name_and_open_parenthesis        = false
+csharp_space_between_method_declaration_parameter_list_parentheses       = false
+csharp_space_between_parentheses                                         = false
+csharp_space_between_square_brackets                                     = false
+
+# Wrapping preferences
+csharp_preserve_single_line_blocks     = true
+csharp_preserve_single_line_statements = true
+
+# Namespace preferences
+csharp_style_namespace_declarations = file_scoped:warning
+dotnet_style_namespace_match_folder = false
+
+# Constructor preferences
+csharp_style_prefer_primary_constructors = false:none
+
+
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.symbols  = types_and_namespaces
+dotnet_naming_rule.types_and_namespaces_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.interfaces_should_be_ipascalcase.severity = suggestion
+dotnet_naming_rule.interfaces_should_be_ipascalcase.symbols  = interfaces
+dotnet_naming_rule.interfaces_should_be_ipascalcase.style    = ipascalcase
+
+dotnet_naming_rule.non_field_members_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascalcase.symbols  = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.constant_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascalcase.symbols  = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.public_static_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.public_static_fields_should_be_pascalcase.symbols  = public_static_fields
+dotnet_naming_rule.public_static_fields_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.public_fields_should_be_pascalcase.severity = suggestion
+dotnet_naming_rule.public_fields_should_be_pascalcase.symbols  = public_fields
+dotnet_naming_rule.public_fields_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.private_fields_should_be__camelcase.severity = suggestion
+dotnet_naming_rule.private_fields_should_be__camelcase.symbols  = private_fields
+dotnet_naming_rule.private_fields_should_be__camelcase.style    = _camelcase
+
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.severity = warning
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.symbols  = type_parameters
+dotnet_naming_rule.type_parameters_should_be_tpascalcase.style    = tpascalcase
+
+dotnet_naming_rule.parameters_should_be_camelcase.severity = suggestion
+dotnet_naming_rule.parameters_should_be_camelcase.symbols  = parameters
+dotnet_naming_rule.parameters_should_be_camelcase.style    = camelcase
+
+dotnet_naming_rule.local_constants_should_be_pascalcase.severity = warning
+dotnet_naming_rule.local_constants_should_be_pascalcase.symbols  = local_constants
+dotnet_naming_rule.local_constants_should_be_pascalcase.style    = pascalcase
+
+dotnet_naming_rule.local_variables_should_be_camelcase.severity = warning
+dotnet_naming_rule.local_variables_should_be_camelcase.symbols  = local_variables
+dotnet_naming_rule.local_variables_should_be_camelcase.style    = camelcase
+
+dotnet_naming_rule.local_functions_should_be_camelcase.severity = warning
+dotnet_naming_rule.local_functions_should_be_camelcase.symbols  = local_functions
+dotnet_naming_rule.local_functions_should_be_camelcase.style    = camelcase
+
+# Symbol specifications
+
+dotnet_naming_symbols.types_and_namespaces.applicable_kinds           = namespace, class, struct, interface, enum
+dotnet_naming_symbols.types_and_namespaces.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types_and_namespaces.required_modifiers         =
+
+dotnet_naming_symbols.interfaces.applicable_kinds           = interface
+dotnet_naming_symbols.interfaces.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interfaces.required_modifiers         =
+
+dotnet_naming_symbols.non_field_members.applicable_kinds           = property, event, delegate, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers         =
+
+dotnet_naming_symbols.constant_fields.applicable_kinds           = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.constant_fields.required_modifiers         = const
+
+dotnet_naming_symbols.public_static_fields.applicable_kinds           = field
+dotnet_naming_symbols.public_static_fields.applicable_accessibilities = public, internal
+dotnet_naming_symbols.public_static_fields.required_modifiers         = static
+
+dotnet_naming_symbols.public_fields.applicable_kinds           = field
+dotnet_naming_symbols.public_fields.applicable_accessibilities = public, internal
+dotnet_naming_symbols.public_fields.required_modifiers         =
+
+dotnet_naming_symbols.private_fields.applicable_kinds           = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = private, protected, protected_internal, private_protected
+dotnet_naming_symbols.private_fields.required_modifiers         =
+
+dotnet_naming_symbols.type_parameters.applicable_kinds           = type_parameter
+dotnet_naming_symbols.type_parameters.applicable_accessibilities = *
+dotnet_naming_symbols.type_parameters.required_modifiers         =
+
+dotnet_naming_symbols.parameters.applicable_kinds           = parameter
+dotnet_naming_symbols.parameters.applicable_accessibilities = *
+dotnet_naming_symbols.parameters.required_modifiers         =
+
+dotnet_naming_symbols.local_constants.applicable_kinds           = local
+dotnet_naming_symbols.local_constants.applicable_accessibilities = local
+dotnet_naming_symbols.local_constants.required_modifiers         = const
+
+dotnet_naming_symbols.local_variables.applicable_kinds           = local
+dotnet_naming_symbols.local_variables.applicable_accessibilities = local
+dotnet_naming_symbols.local_variables.required_modifiers         =
+
+dotnet_naming_symbols.local_functions.applicable_kinds           = local_function
+dotnet_naming_symbols.local_functions.applicable_accessibilities = local
+dotnet_naming_symbols.local_functions.required_modifiers         =
+
+# Naming styles
+
+dotnet_naming_style.pascalcase.required_prefix =
+dotnet_naming_style.pascalcase.required_suffix =
+dotnet_naming_style.pascalcase.word_separator  =
+dotnet_naming_style.pascalcase.capitalization  = pascal_case
+
+dotnet_naming_style.ipascalcase.required_prefix = I
+dotnet_naming_style.ipascalcase.required_suffix =
+dotnet_naming_style.ipascalcase.word_separator  =
+dotnet_naming_style.ipascalcase.capitalization  = pascal_case
+
+dotnet_naming_style.tpascalcase.required_prefix = T
+dotnet_naming_style.tpascalcase.required_suffix =
+dotnet_naming_style.tpascalcase.word_separator  =
+dotnet_naming_style.tpascalcase.capitalization  = pascal_case
+
+dotnet_naming_style.camelcase.required_prefix =
+dotnet_naming_style.camelcase.required_suffix =
+dotnet_naming_style.camelcase.word_separator  =
+dotnet_naming_style.camelcase.capitalization  = camel_case
+
+dotnet_naming_style._camelcase.required_prefix = _
+dotnet_naming_style._camelcase.required_suffix =
+dotnet_naming_style._camelcase.word_separator  =
+dotnet_naming_style._camelcase.capitalization  = camel_case
+
+
+#### Suppressions ####

--- a/props/LiveSplit.Sound.props
+++ b/props/LiveSplit.Sound.props
@@ -4,6 +4,7 @@
   <PropertyGroup>
     <LangVersion>12</LangVersion>
 
+    <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <Nullable>disable</Nullable>
   </PropertyGroup>
 

--- a/props/LiveSplit.Sound.props
+++ b/props/LiveSplit.Sound.props
@@ -2,6 +2,8 @@
 
   <!-- Project properties. -->
   <PropertyGroup>
+    <LangVersion>12</LangVersion>
+
     <Nullable>disable</Nullable>
   </PropertyGroup>
 

--- a/src/LiveSplit.Sound/LiveSplit.Sound.csproj
+++ b/src/LiveSplit.Sound/LiveSplit.Sound.csproj
@@ -14,6 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="NAudio" Version="1.7.3" />
+    <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/src/LiveSplit.Sound/UI/Components/SoundComponent.cs
+++ b/src/LiveSplit.Sound/UI/Components/SoundComponent.cs
@@ -180,8 +180,10 @@ public class SoundComponent : LogicComponent, IDeactivatableComponent
             {
                 try
                 {
-                    AudioFileReader audioFileReader = new AudioFileReader(location);
-                    audioFileReader.Volume = volume / 100f * (Settings.GeneralVolume / 100f);
+                    AudioFileReader audioFileReader = new AudioFileReader(location)
+                    {
+                        Volume = volume / 100f * (Settings.GeneralVolume / 100f)
+                    };
 
                     Player.DeviceNumber = Settings.OutputDevice;
                     Player.Init(audioFileReader);

--- a/src/LiveSplit.Sound/UI/Components/SoundComponent.cs
+++ b/src/LiveSplit.Sound/UI/Components/SoundComponent.cs
@@ -1,190 +1,191 @@
-﻿using LiveSplit.Model;
-using LiveSplit.Options;
-using NAudio.Wave;
-using System;
+﻿using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using System.Xml;
 
-namespace LiveSplit.UI.Components
+using LiveSplit.Model;
+using LiveSplit.Options;
+
+using NAudio.Wave;
+
+namespace LiveSplit.UI.Components;
+
+public class SoundComponent : LogicComponent, IDeactivatableComponent
 {
-    public class SoundComponent : LogicComponent, IDeactivatableComponent
+    public override string ComponentName => "Sound Effects";
+
+    public bool Activated { get; set; }
+
+    private LiveSplitState State { get; set; }
+    private SoundSettings Settings { get; set; }
+    private WaveOut Player { get; set; }
+
+    public SoundComponent(LiveSplitState state)
     {
-        public override string ComponentName => "Sound Effects";
+        Activated = true;
 
-        public bool Activated { get; set; }
+        State = state;
+        Settings = new SoundSettings();
+        Player = new WaveOut();
 
-        private LiveSplitState State { get; set; }
-        private SoundSettings Settings { get; set; }
-        private WaveOut Player { get; set; }
-
-        public SoundComponent(LiveSplitState state)
-        {
-            Activated = true;
-
-            State = state;
-            Settings = new SoundSettings();
-            Player = new WaveOut();
-
-            State.OnStart += State_OnStart;
-            State.OnSplit += State_OnSplit;
-            State.OnSkipSplit += State_OnSkipSplit;
-            State.OnUndoSplit += State_OnUndoSplit;
-            State.OnPause += State_OnPause;
-            State.OnResume += State_OnResume;
-            State.OnReset += State_OnReset;
-        }
-
-        public override void Dispose()
-        {
-            State.OnStart -= State_OnStart;
-            State.OnSplit -= State_OnSplit;
-            State.OnSkipSplit -= State_OnSkipSplit;
-            State.OnUndoSplit -= State_OnUndoSplit;
-            State.OnPause -= State_OnPause;
-            State.OnResume -= State_OnResume;
-            State.OnReset -= State_OnReset;
-
-            Player.Stop();
-        }
-
-        public override void Update(IInvalidator invalidator, LiveSplitState state, float width, float height, LayoutMode mode) { }
-
-        public override Control GetSettingsControl(LayoutMode mode)
-        {
-            return Settings;
-        }
-
-        public override XmlNode GetSettings(XmlDocument document)
-        {
-            return Settings.GetSettings(document);
-        }
-
-        public override void SetSettings(XmlNode settings)
-        {
-            Settings.SetSettings(settings);
-        }
-
-        private void State_OnStart(object sender, EventArgs e)
-        {
-            PlaySound(Settings.StartTimer, Settings.StartTimerVolume);
-        }
-
-        private void State_OnSplit(object sender, EventArgs e)
-        {
-            if (State.CurrentPhase == TimerPhase.Ended)
-            {
-                if (State.Run.Last().PersonalBestSplitTime[State.CurrentTimingMethod] == null || State.Run.Last().SplitTime[State.CurrentTimingMethod] < State.Run.Last().PersonalBestSplitTime[State.CurrentTimingMethod])
-                    PlaySound(Settings.PersonalBest, Settings.PersonalBestVolume);
-                else
-                    PlaySound(Settings.NotAPersonalBest, Settings.NotAPersonalBestVolume);
-            }
-            else
-            {
-                var path = string.Empty;
-                int volume = Settings.SplitVolume;
-
-                var splitIndex = State.CurrentSplitIndex - 1;
-                var timeDifference = State.Run[splitIndex].SplitTime[State.CurrentTimingMethod] - State.Run[splitIndex].Comparisons[State.CurrentComparison][State.CurrentTimingMethod];
-
-                if (timeDifference != null)
-                {
-                    if (timeDifference < TimeSpan.Zero)
-                    {
-                        path = Settings.SplitAheadGaining;
-                        volume = Settings.SplitAheadGainingVolume;
-
-                        if (LiveSplitStateHelper.GetPreviousSegmentDelta(State, splitIndex, State.CurrentComparison, State.CurrentTimingMethod) > TimeSpan.Zero)
-                        {
-                            path = Settings.SplitAheadLosing;
-                            volume = Settings.SplitAheadLosingVolume;
-                        }
-                    }
-                    else
-                    {
-                        path = Settings.SplitBehindLosing;
-                        volume = Settings.SplitBehindLosingVolume;
-
-                        if (LiveSplitStateHelper.GetPreviousSegmentDelta(State, splitIndex, State.CurrentComparison, State.CurrentTimingMethod) < TimeSpan.Zero)
-                        {
-                            path = Settings.SplitBehindGaining;
-                            volume = Settings.SplitBehindGainingVolume;
-                        }
-                    }
-                }
-
-                //Check for best segment
-                TimeSpan? curSegment = LiveSplitStateHelper.GetPreviousSegmentTime(State, splitIndex, State.CurrentTimingMethod);
-
-                if (curSegment != null)
-                {
-                    if (State.Run[splitIndex].BestSegmentTime[State.CurrentTimingMethod] == null || curSegment < State.Run[splitIndex].BestSegmentTime[State.CurrentTimingMethod])
-                    {
-                        path = Settings.BestSegment;
-                        volume = Settings.BestSegmentVolume;
-                    }
-                }
-
-                if (string.IsNullOrEmpty(path))
-                    path = Settings.Split;
-
-                PlaySound(path, volume);
-            }
-        }
-
-        private void State_OnSkipSplit(object sender, EventArgs e)
-        {
-            PlaySound(Settings.SkipSplit, Settings.SkipSplitVolume);
-        }
-
-        private void State_OnUndoSplit(object sender, EventArgs e)
-        {
-            PlaySound(Settings.UndoSplit, Settings.UndoSplitVolume);
-        }
-
-        private void State_OnPause(object sender, EventArgs e)
-        {
-            PlaySound(Settings.Pause, Settings.PauseVolume);
-        }
-
-        private void State_OnResume(object sender, EventArgs e)
-        {
-            PlaySound(Settings.Resume, Settings.ResumeVolume);
-        }
-
-        private void State_OnReset(object sender, TimerPhase e)
-        {
-            if (e != TimerPhase.Ended)
-                PlaySound(Settings.Reset, Settings.ResetVolume);
-        }
-
-        private void PlaySound(string location, int volume)
-        {
-            Player.Stop();
-
-            if (Activated && File.Exists(location))
-            {
-                Task.Factory.StartNew(() =>
-                {
-                    try
-                    {
-                        AudioFileReader audioFileReader = new AudioFileReader(location);
-                        audioFileReader.Volume = (volume / 100f) * (Settings.GeneralVolume / 100f);
-
-                        Player.DeviceNumber = Settings.OutputDevice;
-                        Player.Init(audioFileReader);
-                        Player.Play();
-                    }
-                    catch (Exception e)
-                    {
-                        Log.Error(e);
-                    }
-                });
-            }
-        }
-
-        public int GetSettingsHashCode() => Settings.GetSettingsHashCode();
+        State.OnStart += State_OnStart;
+        State.OnSplit += State_OnSplit;
+        State.OnSkipSplit += State_OnSkipSplit;
+        State.OnUndoSplit += State_OnUndoSplit;
+        State.OnPause += State_OnPause;
+        State.OnResume += State_OnResume;
+        State.OnReset += State_OnReset;
     }
+
+    public override void Dispose()
+    {
+        State.OnStart -= State_OnStart;
+        State.OnSplit -= State_OnSplit;
+        State.OnSkipSplit -= State_OnSkipSplit;
+        State.OnUndoSplit -= State_OnUndoSplit;
+        State.OnPause -= State_OnPause;
+        State.OnResume -= State_OnResume;
+        State.OnReset -= State_OnReset;
+
+        Player.Stop();
+    }
+
+    public override void Update(IInvalidator invalidator, LiveSplitState state, float width, float height, LayoutMode mode) { }
+
+    public override Control GetSettingsControl(LayoutMode mode)
+    {
+        return Settings;
+    }
+
+    public override XmlNode GetSettings(XmlDocument document)
+    {
+        return Settings.GetSettings(document);
+    }
+
+    public override void SetSettings(XmlNode settings)
+    {
+        Settings.SetSettings(settings);
+    }
+
+    private void State_OnStart(object sender, EventArgs e)
+    {
+        PlaySound(Settings.StartTimer, Settings.StartTimerVolume);
+    }
+
+    private void State_OnSplit(object sender, EventArgs e)
+    {
+        if (State.CurrentPhase == TimerPhase.Ended)
+        {
+            if (State.Run.Last().PersonalBestSplitTime[State.CurrentTimingMethod] == null || State.Run.Last().SplitTime[State.CurrentTimingMethod] < State.Run.Last().PersonalBestSplitTime[State.CurrentTimingMethod])
+                PlaySound(Settings.PersonalBest, Settings.PersonalBestVolume);
+            else
+                PlaySound(Settings.NotAPersonalBest, Settings.NotAPersonalBestVolume);
+        }
+        else
+        {
+            var path = string.Empty;
+            int volume = Settings.SplitVolume;
+
+            var splitIndex = State.CurrentSplitIndex - 1;
+            var timeDifference = State.Run[splitIndex].SplitTime[State.CurrentTimingMethod] - State.Run[splitIndex].Comparisons[State.CurrentComparison][State.CurrentTimingMethod];
+
+            if (timeDifference != null)
+            {
+                if (timeDifference < TimeSpan.Zero)
+                {
+                    path = Settings.SplitAheadGaining;
+                    volume = Settings.SplitAheadGainingVolume;
+
+                    if (LiveSplitStateHelper.GetPreviousSegmentDelta(State, splitIndex, State.CurrentComparison, State.CurrentTimingMethod) > TimeSpan.Zero)
+                    {
+                        path = Settings.SplitAheadLosing;
+                        volume = Settings.SplitAheadLosingVolume;
+                    }
+                }
+                else
+                {
+                    path = Settings.SplitBehindLosing;
+                    volume = Settings.SplitBehindLosingVolume;
+
+                    if (LiveSplitStateHelper.GetPreviousSegmentDelta(State, splitIndex, State.CurrentComparison, State.CurrentTimingMethod) < TimeSpan.Zero)
+                    {
+                        path = Settings.SplitBehindGaining;
+                        volume = Settings.SplitBehindGainingVolume;
+                    }
+                }
+            }
+
+            //Check for best segment
+            TimeSpan? curSegment = LiveSplitStateHelper.GetPreviousSegmentTime(State, splitIndex, State.CurrentTimingMethod);
+
+            if (curSegment != null)
+            {
+                if (State.Run[splitIndex].BestSegmentTime[State.CurrentTimingMethod] == null || curSegment < State.Run[splitIndex].BestSegmentTime[State.CurrentTimingMethod])
+                {
+                    path = Settings.BestSegment;
+                    volume = Settings.BestSegmentVolume;
+                }
+            }
+
+            if (string.IsNullOrEmpty(path))
+                path = Settings.Split;
+
+            PlaySound(path, volume);
+        }
+    }
+
+    private void State_OnSkipSplit(object sender, EventArgs e)
+    {
+        PlaySound(Settings.SkipSplit, Settings.SkipSplitVolume);
+    }
+
+    private void State_OnUndoSplit(object sender, EventArgs e)
+    {
+        PlaySound(Settings.UndoSplit, Settings.UndoSplitVolume);
+    }
+
+    private void State_OnPause(object sender, EventArgs e)
+    {
+        PlaySound(Settings.Pause, Settings.PauseVolume);
+    }
+
+    private void State_OnResume(object sender, EventArgs e)
+    {
+        PlaySound(Settings.Resume, Settings.ResumeVolume);
+    }
+
+    private void State_OnReset(object sender, TimerPhase e)
+    {
+        if (e != TimerPhase.Ended)
+            PlaySound(Settings.Reset, Settings.ResetVolume);
+    }
+
+    private void PlaySound(string location, int volume)
+    {
+        Player.Stop();
+
+        if (Activated && File.Exists(location))
+        {
+            Task.Factory.StartNew(() =>
+            {
+                try
+                {
+                    AudioFileReader audioFileReader = new AudioFileReader(location);
+                    audioFileReader.Volume = (volume / 100f) * (Settings.GeneralVolume / 100f);
+
+                    Player.DeviceNumber = Settings.OutputDevice;
+                    Player.Init(audioFileReader);
+                    Player.Play();
+                }
+                catch (Exception e)
+                {
+                    Log.Error(e);
+                }
+            });
+        }
+    }
+
+    public int GetSettingsHashCode() => Settings.GetSettingsHashCode();
 }

--- a/src/LiveSplit.Sound/UI/Components/SoundComponent.cs
+++ b/src/LiveSplit.Sound/UI/Components/SoundComponent.cs
@@ -187,5 +187,8 @@ public class SoundComponent : LogicComponent, IDeactivatableComponent
         }
     }
 
-    public int GetSettingsHashCode() => Settings.GetSettingsHashCode();
+    public int GetSettingsHashCode()
+    {
+        return Settings.GetSettingsHashCode();
+    }
 }

--- a/src/LiveSplit.Sound/UI/Components/SoundComponent.cs
+++ b/src/LiveSplit.Sound/UI/Components/SoundComponent.cs
@@ -89,11 +89,11 @@ public class SoundComponent : LogicComponent, IDeactivatableComponent
         }
         else
         {
-            var path = string.Empty;
+            string path = string.Empty;
             int volume = Settings.SplitVolume;
 
-            var splitIndex = State.CurrentSplitIndex - 1;
-            var timeDifference = State.Run[splitIndex].SplitTime[State.CurrentTimingMethod] - State.Run[splitIndex].Comparisons[State.CurrentComparison][State.CurrentTimingMethod];
+            int splitIndex = State.CurrentSplitIndex - 1;
+            TimeSpan? timeDifference = State.Run[splitIndex].SplitTime[State.CurrentTimingMethod] - State.Run[splitIndex].Comparisons[State.CurrentComparison][State.CurrentTimingMethod];
 
             if (timeDifference != null)
             {
@@ -180,7 +180,7 @@ public class SoundComponent : LogicComponent, IDeactivatableComponent
             {
                 try
                 {
-                    AudioFileReader audioFileReader = new AudioFileReader(location)
+                    var audioFileReader = new AudioFileReader(location)
                     {
                         Volume = volume / 100f * (Settings.GeneralVolume / 100f)
                     };

--- a/src/LiveSplit.Sound/UI/Components/SoundComponent.cs
+++ b/src/LiveSplit.Sound/UI/Components/SoundComponent.cs
@@ -79,9 +79,13 @@ public class SoundComponent : LogicComponent, IDeactivatableComponent
         if (State.CurrentPhase == TimerPhase.Ended)
         {
             if (State.Run.Last().PersonalBestSplitTime[State.CurrentTimingMethod] == null || State.Run.Last().SplitTime[State.CurrentTimingMethod] < State.Run.Last().PersonalBestSplitTime[State.CurrentTimingMethod])
+            {
                 PlaySound(Settings.PersonalBest, Settings.PersonalBestVolume);
+            }
             else
+            {
                 PlaySound(Settings.NotAPersonalBest, Settings.NotAPersonalBestVolume);
+            }
         }
         else
         {
@@ -130,7 +134,9 @@ public class SoundComponent : LogicComponent, IDeactivatableComponent
             }
 
             if (string.IsNullOrEmpty(path))
+            {
                 path = Settings.Split;
+            }
 
             PlaySound(path, volume);
         }
@@ -159,7 +165,9 @@ public class SoundComponent : LogicComponent, IDeactivatableComponent
     private void State_OnReset(object sender, TimerPhase e)
     {
         if (e != TimerPhase.Ended)
+        {
             PlaySound(Settings.Reset, Settings.ResetVolume);
+        }
     }
 
     private void PlaySound(string location, int volume)
@@ -173,7 +181,7 @@ public class SoundComponent : LogicComponent, IDeactivatableComponent
                 try
                 {
                     AudioFileReader audioFileReader = new AudioFileReader(location);
-                    audioFileReader.Volume = (volume / 100f) * (Settings.GeneralVolume / 100f);
+                    audioFileReader.Volume = volume / 100f * (Settings.GeneralVolume / 100f);
 
                     Player.DeviceNumber = Settings.OutputDevice;
                     Player.Init(audioFileReader);

--- a/src/LiveSplit.Sound/UI/Components/SoundFactory.cs
+++ b/src/LiveSplit.Sound/UI/Components/SoundFactory.cs
@@ -1,27 +1,27 @@
-﻿using LiveSplit.Model;
+﻿using System;
+
+using LiveSplit.Model;
 using LiveSplit.UI.Components;
-using System;
 
 [assembly: ComponentFactory(typeof(SoundFactory))]
 
-namespace LiveSplit.UI.Components
+namespace LiveSplit.UI.Components;
+
+public class SoundFactory : IComponentFactory
 {
-    public class SoundFactory : IComponentFactory
-    {
-        public string ComponentName => "Sound Effects";
+    public string ComponentName => "Sound Effects";
 
-        public string Description => "Plays sound effects for different situations.";
+    public string Description => "Plays sound effects for different situations.";
 
-        public ComponentCategory Category => ComponentCategory.Media;
+    public ComponentCategory Category => ComponentCategory.Media;
 
-        public IComponent Create(LiveSplitState state) => new SoundComponent(state);
+    public IComponent Create(LiveSplitState state) => new SoundComponent(state);
 
-        public string UpdateName => ComponentName;
+    public string UpdateName => ComponentName;
 
-        public string XMLURL => "http://livesplit.org/update/Components/update.LiveSplit.Sound.xml";
+    public string XMLURL => "http://livesplit.org/update/Components/update.LiveSplit.Sound.xml";
 
-        public string UpdateURL => "http://livesplit.org/update/";
+    public string UpdateURL => "http://livesplit.org/update/";
 
-        public Version Version => Version.Parse("1.8.29");
-    }
+    public Version Version => Version.Parse("1.8.29");
 }

--- a/src/LiveSplit.Sound/UI/Components/SoundFactory.cs
+++ b/src/LiveSplit.Sound/UI/Components/SoundFactory.cs
@@ -15,7 +15,10 @@ public class SoundFactory : IComponentFactory
 
     public ComponentCategory Category => ComponentCategory.Media;
 
-    public IComponent Create(LiveSplitState state) => new SoundComponent(state);
+    public IComponent Create(LiveSplitState state)
+    {
+        return new SoundComponent(state);
+    }
 
     public string UpdateName => ComponentName;
 

--- a/src/LiveSplit.Sound/UI/Components/SoundSettings.cs
+++ b/src/LiveSplit.Sound/UI/Components/SoundSettings.cs
@@ -79,7 +79,9 @@ public partial class SoundSettings : UserControl
         StartTimerVolume = 100;
 
         for (int i = 0; i < WaveOut.DeviceCount; ++i)
+        {
             cbOutputDevice.Items.Add(WaveOut.GetCapabilities(i));
+        }
 
         txtSplitPath.DataBindings.Add("Text", this, "Split");
         txtSplitAheadGaining.DataBindings.Add("Text", this, "SplitAheadGaining");
@@ -212,7 +214,9 @@ public partial class SoundSettings : UserControl
         var result = fileDialog.ShowDialog();
 
         if (result == DialogResult.OK)
+        {
             path = fileDialog.FileName;
+        }
 
         textBox.Text = path;
         callback(path);

--- a/src/LiveSplit.Sound/UI/Components/SoundSettings.cs
+++ b/src/LiveSplit.Sound/UI/Components/SoundSettings.cs
@@ -1,299 +1,299 @@
-﻿using NAudio.Wave;
-using System;
+﻿using System;
 using System.Windows.Forms;
 using System.Xml;
 
-namespace LiveSplit.UI.Components
+using NAudio.Wave;
+
+namespace LiveSplit.UI.Components;
+
+public partial class SoundSettings : UserControl
 {
-    public partial class SoundSettings : UserControl
+    public string Split { get; set; }
+    public string SplitAheadGaining { get; set; }
+    public string SplitAheadLosing { get; set; }
+    public string SplitBehindGaining { get; set; }
+    public string SplitBehindLosing { get; set; }
+    public string BestSegment { get; set; }
+    public string UndoSplit { get; set; }
+    public string SkipSplit { get; set; }
+    public string PersonalBest { get; set; }
+    public string NotAPersonalBest { get; set; }
+    public string Reset { get; set; }
+    public string Pause { get; set; }
+    public string Resume { get; set; }
+    public string StartTimer { get; set; }
+
+    public int OutputDevice { get; set; }
+
+    public int GeneralVolume { get; set; }
+    public int SplitVolume { get; set; }
+    public int SplitAheadGainingVolume { get; set; }
+    public int SplitAheadLosingVolume { get; set; }
+    public int SplitBehindGainingVolume { get; set; }
+    public int SplitBehindLosingVolume { get; set; }
+    public int BestSegmentVolume { get; set; }
+    public int UndoSplitVolume { get; set; }
+    public int SkipSplitVolume { get; set; }
+    public int PersonalBestVolume { get; set; }
+    public int NotAPersonalBestVolume { get; set; }
+    public int ResetVolume { get; set; }
+    public int PauseVolume { get; set; }
+    public int ResumeVolume { get; set; }
+    public int StartTimerVolume { get; set; }
+
+    public SoundSettings()
     {
-        public string Split { get; set; }
-        public string SplitAheadGaining { get; set; }
-        public string SplitAheadLosing { get; set; }
-        public string SplitBehindGaining { get; set; }
-        public string SplitBehindLosing { get; set; }
-        public string BestSegment { get; set; }
-        public string UndoSplit { get; set; }
-        public string SkipSplit { get; set; }
-        public string PersonalBest { get; set; }
-        public string NotAPersonalBest { get; set; }
-        public string Reset { get; set; }
-        public string Pause { get; set; }
-        public string Resume { get; set; }
-        public string StartTimer { get; set; }
+        InitializeComponent();
 
-        public int OutputDevice { get; set; }
+        Split =
+        SplitAheadGaining =
+        SplitAheadLosing =
+        SplitBehindGaining =
+        SplitBehindLosing =
+        BestSegment =
+        UndoSplit =
+        SkipSplit =
+        PersonalBest =
+        NotAPersonalBest =
+        Reset =
+        Pause =
+        Resume =
+        StartTimer = "";
 
-        public int GeneralVolume { get; set; }
-        public int SplitVolume { get; set; }
-        public int SplitAheadGainingVolume { get; set; }
-        public int SplitAheadLosingVolume { get; set; }
-        public int SplitBehindGainingVolume { get; set; }
-        public int SplitBehindLosingVolume { get; set; }
-        public int BestSegmentVolume { get; set; }
-        public int UndoSplitVolume { get; set; }
-        public int SkipSplitVolume { get; set; }
-        public int PersonalBestVolume { get; set; }
-        public int NotAPersonalBestVolume { get; set; }
-        public int ResetVolume { get; set; }
-        public int PauseVolume { get; set; }
-        public int ResumeVolume { get; set; }
-        public int StartTimerVolume { get; set; }
+        OutputDevice = 0;
 
-        public SoundSettings()
+        GeneralVolume =
+        SplitVolume =
+        SplitAheadGainingVolume =
+        SplitAheadLosingVolume =
+        SplitBehindGainingVolume =
+        SplitBehindLosingVolume =
+        BestSegmentVolume =
+        UndoSplitVolume =
+        SkipSplitVolume =
+        PersonalBestVolume =
+        NotAPersonalBestVolume =
+        ResetVolume =
+        PauseVolume =
+        ResumeVolume =
+        StartTimerVolume = 100;
+
+        for (int i = 0; i < WaveOut.DeviceCount; ++i)
+            cbOutputDevice.Items.Add(WaveOut.GetCapabilities(i));
+
+        txtSplitPath.DataBindings.Add("Text", this, "Split");
+        txtSplitAheadGaining.DataBindings.Add("Text", this, "SplitAheadGaining");
+        txtSplitAheadLosing.DataBindings.Add("Text", this, "SplitAheadLosing");
+        txtSplitBehindGaining.DataBindings.Add("Text", this, "SplitBehindGaining");
+        txtSplitBehindLosing.DataBindings.Add("Text", this, "SplitBehindLosing");
+        txtBestSegment.DataBindings.Add("Text", this, "BestSegment");
+        txtUndo.DataBindings.Add("Text", this, "UndoSplit");
+        txtSkip.DataBindings.Add("Text", this, "SkipSplit");
+        txtPersonalBest.DataBindings.Add("Text", this, "PersonalBest");
+        txtNotAPersonalBest.DataBindings.Add("Text", this, "NotAPersonalBest");
+        txtReset.DataBindings.Add("Text", this, "Reset");
+        txtPause.DataBindings.Add("Text", this, "Pause");
+        txtResume.DataBindings.Add("Text", this, "Resume");
+        txtStartTimer.DataBindings.Add("Text", this, "StartTimer");
+
+        cbOutputDevice.DataBindings.Add("SelectedIndex", this, "OutputDevice");
+
+        tbGeneralVolume.DataBindings.Add("Value", this, "GeneralVolume");
+        tbSplitVolume.DataBindings.Add("Value", this, "SplitVolume");
+        tbSplitAheadGainingVolume.DataBindings.Add("Value", this, "SplitAheadGainingVolume");
+        tbSplitAheadLosingVolume.DataBindings.Add("Value", this, "SplitAheadLosingVolume");
+        tbSplitBehindGainingVolume.DataBindings.Add("Value", this, "SplitBehindGainingVolume");
+        tbSplitBehindLosingVolume.DataBindings.Add("Value", this, "SplitBehindLosingVolume");
+        tbBestSegmentVolume.DataBindings.Add("Value", this, "BestSegmentVolume");
+        tbUndoVolume.DataBindings.Add("Value", this, "UndoSplitVolume");
+        tbSkipVolume.DataBindings.Add("Value", this, "SkipSplitVolume");
+        tbPersonalBestVolume.DataBindings.Add("Value", this, "PersonalBestVolume");
+        tbNotAPersonalBestVolume.DataBindings.Add("Value", this, "NotAPersonalBestVolume");
+        tbResetVolume.DataBindings.Add("Value", this, "ResetVolume");
+        tbPauseVolume.DataBindings.Add("Value", this, "PauseVolume");
+        tbResumeVolume.DataBindings.Add("Value", this, "ResumeVolume");
+        tbStartTimerVolume.DataBindings.Add("Value", this, "StartTimerVolume");
+    }
+
+    public void SetSettings(XmlNode node)
+    {
+        var element = (XmlElement)node;
+
+        Split = SettingsHelper.ParseString(element["Split"]);
+        SplitAheadGaining = SettingsHelper.ParseString(element["SplitAheadGaining"]);
+        SplitAheadLosing = SettingsHelper.ParseString(element["SplitAheadLosing"]);
+        SplitBehindGaining = SettingsHelper.ParseString(element["SplitBehindGaining"]);
+        SplitBehindLosing = SettingsHelper.ParseString(element["SplitBehindLosing"]);
+        BestSegment = SettingsHelper.ParseString(element["BestSegment"]);
+        UndoSplit = SettingsHelper.ParseString(element["UndoSplit"]);
+        SkipSplit = SettingsHelper.ParseString(element["SkipSplit"]);
+        PersonalBest = SettingsHelper.ParseString(element["PersonalBest"]);
+        NotAPersonalBest = SettingsHelper.ParseString(element["NotAPersonalBest"]);
+        Reset = SettingsHelper.ParseString(element["Reset"]);
+        Pause = SettingsHelper.ParseString(element["Pause"]);
+        Resume = SettingsHelper.ParseString(element["Resume"]);
+        StartTimer = SettingsHelper.ParseString(element["StartTimer"]);
+
+        OutputDevice = SettingsHelper.ParseInt(element["OutputDevice"]);
+
+        SplitVolume = SettingsHelper.ParseInt(element["SplitVolume"], 100);
+        SplitAheadGainingVolume = SettingsHelper.ParseInt(element["SplitAheadGainingVolume"], 100);
+        SplitAheadLosingVolume = SettingsHelper.ParseInt(element["SplitAheadLosingVolume"], 100);
+        SplitBehindGainingVolume = SettingsHelper.ParseInt(element["SplitBehindGainingVolume"], 100);
+        SplitBehindLosingVolume = SettingsHelper.ParseInt(element["SplitBehindLosingVolume"], 100);
+        BestSegmentVolume = SettingsHelper.ParseInt(element["BestSegmentVolume"], 100);
+        UndoSplitVolume = SettingsHelper.ParseInt(element["UndoSplitVolume"], 100);
+        SkipSplitVolume = SettingsHelper.ParseInt(element["SkipSplitVolume"], 100);
+        PersonalBestVolume = SettingsHelper.ParseInt(element["PersonalBestVolume"], 100);
+        NotAPersonalBestVolume = SettingsHelper.ParseInt(element["NotAPersonalBestVolume"], 100);
+        ResetVolume = SettingsHelper.ParseInt(element["ResetVolume"], 100);
+        PauseVolume = SettingsHelper.ParseInt(element["PauseVolume"], 100);
+        ResumeVolume = SettingsHelper.ParseInt(element["ResumeVolume"], 100);
+        StartTimerVolume = SettingsHelper.ParseInt(element["StartTimerVolume"], 100);
+        GeneralVolume = SettingsHelper.ParseInt(element["GeneralVolume"], 100);
+    }
+
+    public XmlNode GetSettings(XmlDocument document)
+    {
+        var parent = document.CreateElement("Settings");
+        CreateSettingsNode(document, parent);
+        return parent;
+    }
+
+    public int GetSettingsHashCode()
+    {
+        return CreateSettingsNode(null, null);
+    }
+
+    private int CreateSettingsNode(XmlDocument document, XmlElement parent)
+    {
+        return SettingsHelper.CreateSetting(document, parent, "Version", "1.6") ^
+        SettingsHelper.CreateSetting(document, parent, "Split", Split) ^
+        SettingsHelper.CreateSetting(document, parent, "SplitAheadGaining", SplitAheadGaining) ^
+        SettingsHelper.CreateSetting(document, parent, "SplitAheadLosing", SplitAheadLosing) ^
+        SettingsHelper.CreateSetting(document, parent, "SplitBehindGaining", SplitBehindGaining) ^
+        SettingsHelper.CreateSetting(document, parent, "SplitBehindLosing", SplitBehindLosing) ^
+        SettingsHelper.CreateSetting(document, parent, "BestSegment", BestSegment) ^
+        SettingsHelper.CreateSetting(document, parent, "UndoSplit", UndoSplit) ^
+        SettingsHelper.CreateSetting(document, parent, "SkipSplit", SkipSplit) ^
+        SettingsHelper.CreateSetting(document, parent, "PersonalBest", PersonalBest) ^
+        SettingsHelper.CreateSetting(document, parent, "NotAPersonalBest", NotAPersonalBest) ^
+        SettingsHelper.CreateSetting(document, parent, "Reset", Reset) ^
+        SettingsHelper.CreateSetting(document, parent, "Pause", Pause) ^
+        SettingsHelper.CreateSetting(document, parent, "Resume", Resume) ^
+        SettingsHelper.CreateSetting(document, parent, "StartTimer", StartTimer) ^
+        SettingsHelper.CreateSetting(document, parent, "OutputDevice", OutputDevice) ^
+        SettingsHelper.CreateSetting(document, parent, "SplitVolume", SplitVolume) ^
+        SettingsHelper.CreateSetting(document, parent, "SplitAheadGainingVolume", SplitAheadGainingVolume) ^
+        SettingsHelper.CreateSetting(document, parent, "SplitAheadLosingVolume", SplitAheadLosingVolume) ^
+        SettingsHelper.CreateSetting(document, parent, "SplitBehindGainingVolume", SplitBehindGainingVolume) ^
+        SettingsHelper.CreateSetting(document, parent, "SplitBehindLosingVolume", SplitBehindLosingVolume) ^
+        SettingsHelper.CreateSetting(document, parent, "BestSegmentVolume", BestSegmentVolume) ^
+        SettingsHelper.CreateSetting(document, parent, "UndoSplitVolume", UndoSplitVolume) ^
+        SettingsHelper.CreateSetting(document, parent, "SkipSplitVolume", SkipSplitVolume) ^
+        SettingsHelper.CreateSetting(document, parent, "PersonalBestVolume", PersonalBestVolume) ^
+        SettingsHelper.CreateSetting(document, parent, "NotAPersonalBestVolume", NotAPersonalBestVolume) ^
+        SettingsHelper.CreateSetting(document, parent, "ResetVolume", ResetVolume) ^
+        SettingsHelper.CreateSetting(document, parent, "PauseVolume", PauseVolume) ^
+        SettingsHelper.CreateSetting(document, parent, "ResumeVolume", ResumeVolume) ^
+        SettingsHelper.CreateSetting(document, parent, "StartTimerVolume", StartTimerVolume) ^
+        SettingsHelper.CreateSetting(document, parent, "GeneralVolume", GeneralVolume);
+    }
+
+    protected string BrowseForPath(TextBox textBox, Action<string> callback)
+    {
+        var path = textBox.Text;
+        var fileDialog = new OpenFileDialog()
         {
-            InitializeComponent();
+            FileName = path,
+            Filter = "Audio Files|*.mp3;*.wav;*.aiff;*.wma|All Files|*.*"
+        };
 
-            Split =
-            SplitAheadGaining =
-            SplitAheadLosing =
-            SplitBehindGaining =
-            SplitBehindLosing =
-            BestSegment =
-            UndoSplit =
-            SkipSplit =
-            PersonalBest =
-            NotAPersonalBest =
-            Reset =
-            Pause =
-            Resume =
-            StartTimer = "";
+        var result = fileDialog.ShowDialog();
 
-            OutputDevice = 0;
+        if (result == DialogResult.OK)
+            path = fileDialog.FileName;
 
-            GeneralVolume =
-            SplitVolume =
-            SplitAheadGainingVolume =
-            SplitAheadLosingVolume =
-            SplitBehindGainingVolume =
-            SplitBehindLosingVolume =
-            BestSegmentVolume =
-            UndoSplitVolume =
-            SkipSplitVolume =
-            PersonalBestVolume =
-            NotAPersonalBestVolume =
-            ResetVolume =
-            PauseVolume =
-            ResumeVolume =
-            StartTimerVolume = 100;
+        textBox.Text = path;
+        callback(path);
 
-            for (int i = 0; i < WaveOut.DeviceCount; ++i)
-                cbOutputDevice.Items.Add(WaveOut.GetCapabilities(i));
+        return path;
+    }
 
-            txtSplitPath.DataBindings.Add("Text", this, "Split");
-            txtSplitAheadGaining.DataBindings.Add("Text", this, "SplitAheadGaining");
-            txtSplitAheadLosing.DataBindings.Add("Text", this, "SplitAheadLosing");
-            txtSplitBehindGaining.DataBindings.Add("Text", this, "SplitBehindGaining");
-            txtSplitBehindLosing.DataBindings.Add("Text", this, "SplitBehindLosing");
-            txtBestSegment.DataBindings.Add("Text", this, "BestSegment");
-            txtUndo.DataBindings.Add("Text", this, "UndoSplit");
-            txtSkip.DataBindings.Add("Text", this, "SkipSplit");
-            txtPersonalBest.DataBindings.Add("Text", this, "PersonalBest");
-            txtNotAPersonalBest.DataBindings.Add("Text", this, "NotAPersonalBest");
-            txtReset.DataBindings.Add("Text", this, "Reset");
-            txtPause.DataBindings.Add("Text", this, "Pause");
-            txtResume.DataBindings.Add("Text", this, "Resume");
-            txtStartTimer.DataBindings.Add("Text", this, "StartTimer");
+    private void btnSplit_Click(object sender, EventArgs e)
+    {
+        BrowseForPath(txtSplitPath, (x) => Split = x);
+    }
 
-            cbOutputDevice.DataBindings.Add("SelectedIndex", this, "OutputDevice");
+    private void btnAheadGaining_Click(object sender, EventArgs e)
+    {
+        BrowseForPath(txtSplitAheadGaining, (x) => SplitAheadGaining = x);
+    }
 
-            tbGeneralVolume.DataBindings.Add("Value", this, "GeneralVolume");
-            tbSplitVolume.DataBindings.Add("Value", this, "SplitVolume");
-            tbSplitAheadGainingVolume.DataBindings.Add("Value", this, "SplitAheadGainingVolume");
-            tbSplitAheadLosingVolume.DataBindings.Add("Value", this, "SplitAheadLosingVolume");
-            tbSplitBehindGainingVolume.DataBindings.Add("Value", this, "SplitBehindGainingVolume");
-            tbSplitBehindLosingVolume.DataBindings.Add("Value", this, "SplitBehindLosingVolume");
-            tbBestSegmentVolume.DataBindings.Add("Value", this, "BestSegmentVolume");
-            tbUndoVolume.DataBindings.Add("Value", this, "UndoSplitVolume");
-            tbSkipVolume.DataBindings.Add("Value", this, "SkipSplitVolume");
-            tbPersonalBestVolume.DataBindings.Add("Value", this, "PersonalBestVolume");
-            tbNotAPersonalBestVolume.DataBindings.Add("Value", this, "NotAPersonalBestVolume");
-            tbResetVolume.DataBindings.Add("Value", this, "ResetVolume");
-            tbPauseVolume.DataBindings.Add("Value", this, "PauseVolume");
-            tbResumeVolume.DataBindings.Add("Value", this, "ResumeVolume");
-            tbStartTimerVolume.DataBindings.Add("Value", this, "StartTimerVolume");
-        }
+    private void btnAheadLosing_Click(object sender, EventArgs e)
+    {
+        BrowseForPath(txtSplitAheadLosing, (x) => SplitAheadLosing = x);
+    }
 
-        public void SetSettings(XmlNode node)
-        {
-            var element = (XmlElement)node;
+    private void btnBehindGaining_Click(object sender, EventArgs e)
+    {
+        BrowseForPath(txtSplitBehindGaining, (x) => SplitBehindGaining = x);
+    }
 
-            Split = SettingsHelper.ParseString(element["Split"]);
-            SplitAheadGaining = SettingsHelper.ParseString(element["SplitAheadGaining"]);
-            SplitAheadLosing = SettingsHelper.ParseString(element["SplitAheadLosing"]);
-            SplitBehindGaining = SettingsHelper.ParseString(element["SplitBehindGaining"]);
-            SplitBehindLosing = SettingsHelper.ParseString(element["SplitBehindLosing"]);
-            BestSegment = SettingsHelper.ParseString(element["BestSegment"]);
-            UndoSplit = SettingsHelper.ParseString(element["UndoSplit"]);
-            SkipSplit = SettingsHelper.ParseString(element["SkipSplit"]);
-            PersonalBest = SettingsHelper.ParseString(element["PersonalBest"]);
-            NotAPersonalBest = SettingsHelper.ParseString(element["NotAPersonalBest"]);
-            Reset = SettingsHelper.ParseString(element["Reset"]);
-            Pause = SettingsHelper.ParseString(element["Pause"]);
-            Resume = SettingsHelper.ParseString(element["Resume"]);
-            StartTimer = SettingsHelper.ParseString(element["StartTimer"]);
+    private void btnBehindLosing_Click(object sender, EventArgs e)
+    {
+        BrowseForPath(txtSplitBehindLosing, (x) => SplitBehindLosing = x);
+    }
 
-            OutputDevice = SettingsHelper.ParseInt(element["OutputDevice"]);
+    private void btnBestSegment_Click(object sender, EventArgs e)
+    {
+        BrowseForPath(txtBestSegment, (x) => BestSegment = x);
+    }
 
-            SplitVolume = SettingsHelper.ParseInt(element["SplitVolume"], 100);
-            SplitAheadGainingVolume = SettingsHelper.ParseInt(element["SplitAheadGainingVolume"], 100);
-            SplitAheadLosingVolume = SettingsHelper.ParseInt(element["SplitAheadLosingVolume"], 100);
-            SplitBehindGainingVolume = SettingsHelper.ParseInt(element["SplitBehindGainingVolume"], 100);
-            SplitBehindLosingVolume = SettingsHelper.ParseInt(element["SplitBehindLosingVolume"], 100);
-            BestSegmentVolume = SettingsHelper.ParseInt(element["BestSegmentVolume"], 100);
-            UndoSplitVolume = SettingsHelper.ParseInt(element["UndoSplitVolume"], 100);
-            SkipSplitVolume = SettingsHelper.ParseInt(element["SkipSplitVolume"], 100);
-            PersonalBestVolume = SettingsHelper.ParseInt(element["PersonalBestVolume"], 100);
-            NotAPersonalBestVolume = SettingsHelper.ParseInt(element["NotAPersonalBestVolume"], 100);
-            ResetVolume = SettingsHelper.ParseInt(element["ResetVolume"], 100);
-            PauseVolume = SettingsHelper.ParseInt(element["PauseVolume"], 100);
-            ResumeVolume = SettingsHelper.ParseInt(element["ResumeVolume"], 100);
-            StartTimerVolume = SettingsHelper.ParseInt(element["StartTimerVolume"], 100);
-            GeneralVolume = SettingsHelper.ParseInt(element["GeneralVolume"], 100);
-        }
+    private void btnUndo_Click(object sender, EventArgs e)
+    {
+        BrowseForPath(txtUndo, (x) => UndoSplit = x);
+    }
 
-        public XmlNode GetSettings(XmlDocument document)
-        {
-            var parent = document.CreateElement("Settings");
-            CreateSettingsNode(document, parent);
-            return parent;
-        }
+    private void btnSkipSplit_Click(object sender, EventArgs e)
+    {
+        BrowseForPath(txtSkip, (x) => SkipSplit = x);
+    }
 
-        public int GetSettingsHashCode()
-        {
-            return CreateSettingsNode(null, null);
-        }
+    private void btnPersonalBest_Click(object sender, EventArgs e)
+    {
+        BrowseForPath(txtPersonalBest, (x) => PersonalBest = x);
+    }
 
-        private int CreateSettingsNode(XmlDocument document, XmlElement parent)
-        {
-            return SettingsHelper.CreateSetting(document, parent, "Version", "1.6") ^
-            SettingsHelper.CreateSetting(document, parent, "Split", Split) ^
-            SettingsHelper.CreateSetting(document, parent, "SplitAheadGaining", SplitAheadGaining) ^
-            SettingsHelper.CreateSetting(document, parent, "SplitAheadLosing", SplitAheadLosing) ^
-            SettingsHelper.CreateSetting(document, parent, "SplitBehindGaining", SplitBehindGaining) ^
-            SettingsHelper.CreateSetting(document, parent, "SplitBehindLosing", SplitBehindLosing) ^
-            SettingsHelper.CreateSetting(document, parent, "BestSegment", BestSegment) ^
-            SettingsHelper.CreateSetting(document, parent, "UndoSplit", UndoSplit) ^
-            SettingsHelper.CreateSetting(document, parent, "SkipSplit", SkipSplit) ^
-            SettingsHelper.CreateSetting(document, parent, "PersonalBest", PersonalBest) ^
-            SettingsHelper.CreateSetting(document, parent, "NotAPersonalBest", NotAPersonalBest) ^
-            SettingsHelper.CreateSetting(document, parent, "Reset", Reset) ^
-            SettingsHelper.CreateSetting(document, parent, "Pause", Pause) ^
-            SettingsHelper.CreateSetting(document, parent, "Resume", Resume) ^
-            SettingsHelper.CreateSetting(document, parent, "StartTimer", StartTimer) ^
-            SettingsHelper.CreateSetting(document, parent, "OutputDevice", OutputDevice) ^
-            SettingsHelper.CreateSetting(document, parent, "SplitVolume", SplitVolume) ^
-            SettingsHelper.CreateSetting(document, parent, "SplitAheadGainingVolume", SplitAheadGainingVolume) ^
-            SettingsHelper.CreateSetting(document, parent, "SplitAheadLosingVolume", SplitAheadLosingVolume) ^
-            SettingsHelper.CreateSetting(document, parent, "SplitBehindGainingVolume", SplitBehindGainingVolume) ^
-            SettingsHelper.CreateSetting(document, parent, "SplitBehindLosingVolume", SplitBehindLosingVolume) ^
-            SettingsHelper.CreateSetting(document, parent, "BestSegmentVolume", BestSegmentVolume) ^
-            SettingsHelper.CreateSetting(document, parent, "UndoSplitVolume", UndoSplitVolume) ^
-            SettingsHelper.CreateSetting(document, parent, "SkipSplitVolume", SkipSplitVolume) ^
-            SettingsHelper.CreateSetting(document, parent, "PersonalBestVolume", PersonalBestVolume) ^
-            SettingsHelper.CreateSetting(document, parent, "NotAPersonalBestVolume", NotAPersonalBestVolume) ^
-            SettingsHelper.CreateSetting(document, parent, "ResetVolume", ResetVolume) ^
-            SettingsHelper.CreateSetting(document, parent, "PauseVolume", PauseVolume) ^
-            SettingsHelper.CreateSetting(document, parent, "ResumeVolume", ResumeVolume) ^
-            SettingsHelper.CreateSetting(document, parent, "StartTimerVolume", StartTimerVolume) ^
-            SettingsHelper.CreateSetting(document, parent, "GeneralVolume", GeneralVolume);
-        }
+    private void btnNotAPersonalBest_Click(object sender, EventArgs e)
+    {
+        BrowseForPath(txtNotAPersonalBest, (x) => NotAPersonalBest = x);
+    }
 
-        protected string BrowseForPath(TextBox textBox, Action<string> callback)
-        {
-            var path = textBox.Text;
-            var fileDialog = new OpenFileDialog()
-            {
-                FileName = path,
-                Filter = "Audio Files|*.mp3;*.wav;*.aiff;*.wma|All Files|*.*"
-            };
+    private void btnReset_Click(object sender, EventArgs e)
+    {
+        BrowseForPath(txtReset, (x) => Reset = x);
+    }
 
-            var result = fileDialog.ShowDialog();
+    private void btnPause_Click(object sender, EventArgs e)
+    {
+        BrowseForPath(txtPause, (x) => Pause = x);
+    }
 
-            if (result == DialogResult.OK)
-                path = fileDialog.FileName;
+    private void btnResume_Click(object sender, EventArgs e)
+    {
+        BrowseForPath(txtResume, (x) => Resume = x);
+    }
 
-            textBox.Text = path;
-            callback(path);
+    private void btnStartTimer_Click(object sender, EventArgs e)
+    {
+        BrowseForPath(txtStartTimer, (x) => StartTimer = x);
+    }
 
-            return path;
-        }
+    private void VolumeTrackBarScrollHandler(object sender, EventArgs e)
+    {
+        TrackBar trackBar = (TrackBar)sender;
 
-        private void btnSplit_Click(object sender, EventArgs e)
-        {
-            BrowseForPath(txtSplitPath, (x) => Split = x);
-        }
-
-        private void btnAheadGaining_Click(object sender, EventArgs e)
-        {
-            BrowseForPath(txtSplitAheadGaining, (x) => SplitAheadGaining = x);
-        }
-
-        private void btnAheadLosing_Click(object sender, EventArgs e)
-        {
-            BrowseForPath(txtSplitAheadLosing, (x) => SplitAheadLosing = x);
-        }
-
-        private void btnBehindGaining_Click(object sender, EventArgs e)
-        {
-            BrowseForPath(txtSplitBehindGaining, (x) => SplitBehindGaining = x);
-        }
-
-        private void btnBehindLosing_Click(object sender, EventArgs e)
-        {
-            BrowseForPath(txtSplitBehindLosing, (x) => SplitBehindLosing = x);
-        }
-
-        private void btnBestSegment_Click(object sender, EventArgs e)
-        {
-            BrowseForPath(txtBestSegment, (x) => BestSegment = x);
-        }
-
-        private void btnUndo_Click(object sender, EventArgs e)
-        {
-            BrowseForPath(txtUndo, (x) => UndoSplit = x);
-        }
-
-        private void btnSkipSplit_Click(object sender, EventArgs e)
-        {
-            BrowseForPath(txtSkip, (x) => SkipSplit = x);
-        }
-
-        private void btnPersonalBest_Click(object sender, EventArgs e)
-        {
-            BrowseForPath(txtPersonalBest, (x) => PersonalBest = x);
-        }
-
-        private void btnNotAPersonalBest_Click(object sender, EventArgs e)
-        {
-            BrowseForPath(txtNotAPersonalBest, (x) => NotAPersonalBest = x);
-        }
-
-        private void btnReset_Click(object sender, EventArgs e)
-        {
-            BrowseForPath(txtReset, (x) => Reset = x);
-        }
-
-        private void btnPause_Click(object sender, EventArgs e)
-        {
-            BrowseForPath(txtPause, (x) => Pause = x);
-        }
-
-        private void btnResume_Click(object sender, EventArgs e)
-        {
-            BrowseForPath(txtResume, (x) => Resume = x);
-        }
-
-        private void btnStartTimer_Click(object sender, EventArgs e)
-        {
-            BrowseForPath(txtStartTimer, (x) => StartTimer = x);
-        }
-
-        private void VolumeTrackBarScrollHandler(object sender, EventArgs e)
-        {
-            TrackBar trackBar = (TrackBar)sender;
-
-            ttVolume.SetToolTip(trackBar, trackBar.Value.ToString());
-        }
+        ttVolume.SetToolTip(trackBar, trackBar.Value.ToString());
     }
 }

--- a/src/LiveSplit.Sound/UI/Components/SoundSettings.cs
+++ b/src/LiveSplit.Sound/UI/Components/SoundSettings.cs
@@ -157,7 +157,7 @@ public partial class SoundSettings : UserControl
 
     public XmlNode GetSettings(XmlDocument document)
     {
-        var parent = document.CreateElement("Settings");
+        XmlElement parent = document.CreateElement("Settings");
         CreateSettingsNode(document, parent);
         return parent;
     }
@@ -204,14 +204,14 @@ public partial class SoundSettings : UserControl
 
     protected string BrowseForPath(TextBox textBox, Action<string> callback)
     {
-        var path = textBox.Text;
+        string path = textBox.Text;
         var fileDialog = new OpenFileDialog()
         {
             FileName = path,
             Filter = "Audio Files|*.mp3;*.wav;*.aiff;*.wma|All Files|*.*"
         };
 
-        var result = fileDialog.ShowDialog();
+        DialogResult result = fileDialog.ShowDialog();
 
         if (result == DialogResult.OK)
         {
@@ -296,7 +296,7 @@ public partial class SoundSettings : UserControl
 
     private void VolumeTrackBarScrollHandler(object sender, EventArgs e)
     {
-        TrackBar trackBar = (TrackBar)sender;
+        var trackBar = (TrackBar)sender;
 
         ttVolume.SetToolTip(trackBar, trackBar.Value.ToString());
     }


### PR DESCRIPTION
Parent PR: https://github.com/LiveSplit/LiveSplit/pull/2533

### Description

* Introduces an `.editorconfig` file to enforce consistent style rules.
* Upgrades the language version to C# 12 (most recent stable).
* Adds `PolySharp` to allow for support of some language features which require runtime support (`Index` & `Range` operators).
* Fixes some warnings.
