### PR TITLE
Select multiple sound files and play a random one

### DIFF
--- a/src/LiveSplit.Sound/UI/Components/SoundComponent.cs
+++ b/src/LiveSplit.Sound/UI/Components/SoundComponent.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -92,7 +93,7 @@ public class SoundComponent : LogicComponent, IDeactivatableComponent
         }
         else
         {
-            string path = string.Empty;
+            IList<string> paths = [];
             int volume = Settings.SplitVolume;
 
             int splitIndex = State.CurrentSplitIndex - 1;
@@ -102,23 +103,23 @@ public class SoundComponent : LogicComponent, IDeactivatableComponent
             {
                 if (timeDifference < TimeSpan.Zero)
                 {
-                    path = Settings.SplitAheadGaining;
+                    paths = Settings.SplitAheadGaining;
                     volume = Settings.SplitAheadGainingVolume;
 
                     if (LiveSplitStateHelper.GetPreviousSegmentDelta(State, splitIndex, State.CurrentComparison, State.CurrentTimingMethod) > TimeSpan.Zero)
                     {
-                        path = Settings.SplitAheadLosing;
+                        paths = Settings.SplitAheadLosing;
                         volume = Settings.SplitAheadLosingVolume;
                     }
                 }
                 else
                 {
-                    path = Settings.SplitBehindLosing;
+                    paths = Settings.SplitBehindLosing;
                     volume = Settings.SplitBehindLosingVolume;
 
                     if (LiveSplitStateHelper.GetPreviousSegmentDelta(State, splitIndex, State.CurrentComparison, State.CurrentTimingMethod) < TimeSpan.Zero)
                     {
-                        path = Settings.SplitBehindGaining;
+                        paths = Settings.SplitBehindGaining;
                         volume = Settings.SplitBehindGainingVolume;
                     }
                 }
@@ -131,17 +132,17 @@ public class SoundComponent : LogicComponent, IDeactivatableComponent
             {
                 if (State.Run[splitIndex].BestSegmentTime[State.CurrentTimingMethod] == null || curSegment < State.Run[splitIndex].BestSegmentTime[State.CurrentTimingMethod])
                 {
-                    path = Settings.BestSegment;
+                    paths = Settings.BestSegment;
                     volume = Settings.BestSegmentVolume;
                 }
             }
 
-            if (string.IsNullOrEmpty(path))
+            if (paths.Count == 0)
             {
-                path = Settings.Split;
+                paths = Settings.Split;
             }
 
-            PlaySound(path, volume);
+            PlaySound(paths, volume);
         }
     }
 
@@ -173,26 +174,24 @@ public class SoundComponent : LogicComponent, IDeactivatableComponent
         }
     }
 
-    private void PlaySound(string locations, int volume)
+    private void PlaySound(IList<string> paths, int volume)
     {
         Player.Stop();
 
-        int index = 0;
-        string[] locationsArray = locations.Split(';');
-        if (locationsArray.Length > 1)
+        if (paths.Count == 0)
         {
-            index = Rnd.Next(0, locations.Length);
+            return;
         }
 
-        string location = locationsArray[index];
-
-        if (Activated && File.Exists(location))
+        int index = Rnd.Next(0, paths.Count);
+        string path = paths[index];
+        if (Activated && File.Exists(path))
         {
             Task.Factory.StartNew(() =>
             {
                 try
                 {
-                    var audioFileReader = new AudioFileReader(location)
+                    var audioFileReader = new AudioFileReader(path)
                     {
                         Volume = volume / 100f * (Settings.GeneralVolume / 100f)
                     };

--- a/src/LiveSplit.Sound/UI/Components/SoundComponent.cs
+++ b/src/LiveSplit.Sound/UI/Components/SoundComponent.cs
@@ -21,6 +21,7 @@ public class SoundComponent : LogicComponent, IDeactivatableComponent
     private LiveSplitState State { get; set; }
     private SoundSettings Settings { get; set; }
     private WaveOut Player { get; set; }
+    private Random Rnd { get; set; }
 
     public SoundComponent(LiveSplitState state)
     {
@@ -37,6 +38,8 @@ public class SoundComponent : LogicComponent, IDeactivatableComponent
         State.OnPause += State_OnPause;
         State.OnResume += State_OnResume;
         State.OnReset += State_OnReset;
+
+        Rnd = new Random();
     }
 
     public override void Dispose()
@@ -170,9 +173,18 @@ public class SoundComponent : LogicComponent, IDeactivatableComponent
         }
     }
 
-    private void PlaySound(string location, int volume)
+    private void PlaySound(string locations, int volume)
     {
         Player.Stop();
+
+        int index = 0;
+        string[] locationsArray = locations.Split(';');
+        if (locationsArray.Length > 1)
+        {
+            index = Rnd.Next(0, locations.Length);
+        }
+
+        string location = locationsArray[index];
 
         if (Activated && File.Exists(location))
         {

--- a/src/LiveSplit.Sound/UI/Components/SoundComponent.cs
+++ b/src/LiveSplit.Sound/UI/Components/SoundComponent.cs
@@ -178,15 +178,16 @@ public class SoundComponent : LogicComponent, IDeactivatableComponent
     {
         Player.Stop();
 
-        if (paths.Count == 0)
+        if (Activated)
         {
-            return;
-        }
+            string[] existingPaths = [.. paths.Where(File.Exists)];
+            if (existingPaths.Length == 0)
+            {
+                return;
+            }
 
-        int index = Rnd.Next(0, paths.Count);
-        string path = paths[index];
-        if (Activated && File.Exists(path))
-        {
+            int index = Rnd.Next(0, existingPaths.Length);
+            string path = existingPaths[index];
             Task.Factory.StartNew(() =>
             {
                 try

--- a/src/LiveSplit.Sound/UI/Components/SoundSettings.Designer.cs
+++ b/src/LiveSplit.Sound/UI/Components/SoundSettings.Designer.cs
@@ -123,6 +123,7 @@
             this.label30 = new System.Windows.Forms.Label();
             this.cbOutputDevice = new System.Windows.Forms.ComboBox();
             this.ttVolume = new System.Windows.Forms.ToolTip(this.components);
+            this.ttPaths = new System.Windows.Forms.ToolTip(this.components);
             this.tabControl1.SuspendLayout();
             this.tpSoundFiles.SuspendLayout();
             this.tableLayoutPanel1.SuspendLayout();
@@ -400,6 +401,8 @@
             this.txtStartTimer.ReadOnly = true;
             this.txtStartTimer.Size = new System.Drawing.Size(134, 20);
             this.txtStartTimer.TabIndex = 40;
+            this.txtStartTimer.Enter += new System.EventHandler(this.PathsTextBoxEnterHandler);
+            this.txtStartTimer.Leave += new System.EventHandler(this.PathsTextBoxLeaveHandler);
             // 
             // label14
             // 
@@ -549,6 +552,8 @@
             this.txtResume.ReadOnly = true;
             this.txtResume.Size = new System.Drawing.Size(134, 20);
             this.txtResume.TabIndex = 37;
+            this.txtResume.Enter += new System.EventHandler(this.PathsTextBoxEnterHandler);
+            this.txtResume.Leave += new System.EventHandler(this.PathsTextBoxLeaveHandler);
             // 
             // txtPause
             // 
@@ -558,6 +563,8 @@
             this.txtPause.ReadOnly = true;
             this.txtPause.Size = new System.Drawing.Size(134, 20);
             this.txtPause.TabIndex = 34;
+            this.txtPause.Enter += new System.EventHandler(this.PathsTextBoxEnterHandler);
+            this.txtPause.Leave += new System.EventHandler(this.PathsTextBoxLeaveHandler);
             // 
             // txtReset
             // 
@@ -567,6 +574,8 @@
             this.txtReset.ReadOnly = true;
             this.txtReset.Size = new System.Drawing.Size(134, 20);
             this.txtReset.TabIndex = 31;
+            this.txtReset.Enter += new System.EventHandler(this.PathsTextBoxEnterHandler);
+            this.txtReset.Leave += new System.EventHandler(this.PathsTextBoxLeaveHandler);
             // 
             // txtNotAPersonalBest
             // 
@@ -576,6 +585,8 @@
             this.txtNotAPersonalBest.ReadOnly = true;
             this.txtNotAPersonalBest.Size = new System.Drawing.Size(134, 20);
             this.txtNotAPersonalBest.TabIndex = 28;
+            this.txtNotAPersonalBest.Enter += new System.EventHandler(this.PathsTextBoxEnterHandler);
+            this.txtNotAPersonalBest.Leave += new System.EventHandler(this.PathsTextBoxLeaveHandler);
             // 
             // txtPersonalBest
             // 
@@ -585,6 +596,8 @@
             this.txtPersonalBest.ReadOnly = true;
             this.txtPersonalBest.Size = new System.Drawing.Size(134, 20);
             this.txtPersonalBest.TabIndex = 25;
+            this.txtPersonalBest.Enter += new System.EventHandler(this.PathsTextBoxEnterHandler);
+            this.txtPersonalBest.Leave += new System.EventHandler(this.PathsTextBoxLeaveHandler);
             // 
             // txtSkip
             // 
@@ -594,6 +607,8 @@
             this.txtSkip.ReadOnly = true;
             this.txtSkip.Size = new System.Drawing.Size(134, 20);
             this.txtSkip.TabIndex = 22;
+            this.txtSkip.Enter += new System.EventHandler(this.PathsTextBoxEnterHandler);
+            this.txtSkip.Leave += new System.EventHandler(this.PathsTextBoxLeaveHandler);
             // 
             // txtUndo
             // 
@@ -603,6 +618,8 @@
             this.txtUndo.ReadOnly = true;
             this.txtUndo.Size = new System.Drawing.Size(134, 20);
             this.txtUndo.TabIndex = 19;
+            this.txtUndo.Enter += new System.EventHandler(this.PathsTextBoxEnterHandler);
+            this.txtUndo.Leave += new System.EventHandler(this.PathsTextBoxLeaveHandler);
             // 
             // txtBestSegment
             // 
@@ -612,6 +629,8 @@
             this.txtBestSegment.ReadOnly = true;
             this.txtBestSegment.Size = new System.Drawing.Size(134, 20);
             this.txtBestSegment.TabIndex = 16;
+            this.txtBestSegment.Enter += new System.EventHandler(this.PathsTextBoxEnterHandler);
+            this.txtBestSegment.Leave += new System.EventHandler(this.PathsTextBoxLeaveHandler);
             // 
             // txtSplitBehindLosing
             // 
@@ -621,6 +640,8 @@
             this.txtSplitBehindLosing.ReadOnly = true;
             this.txtSplitBehindLosing.Size = new System.Drawing.Size(134, 20);
             this.txtSplitBehindLosing.TabIndex = 13;
+            this.txtSplitBehindLosing.Enter += new System.EventHandler(this.PathsTextBoxEnterHandler);
+            this.txtSplitBehindLosing.Leave += new System.EventHandler(this.PathsTextBoxLeaveHandler);
             // 
             // txtSplitBehindGaining
             // 
@@ -630,6 +651,8 @@
             this.txtSplitBehindGaining.ReadOnly = true;
             this.txtSplitBehindGaining.Size = new System.Drawing.Size(134, 20);
             this.txtSplitBehindGaining.TabIndex = 10;
+            this.txtSplitBehindGaining.Enter += new System.EventHandler(this.PathsTextBoxEnterHandler);
+            this.txtSplitBehindGaining.Leave += new System.EventHandler(this.PathsTextBoxLeaveHandler);
             // 
             // txtSplitAheadLosing
             // 
@@ -639,6 +662,8 @@
             this.txtSplitAheadLosing.ReadOnly = true;
             this.txtSplitAheadLosing.Size = new System.Drawing.Size(134, 20);
             this.txtSplitAheadLosing.TabIndex = 7;
+            this.txtSplitAheadLosing.Enter += new System.EventHandler(this.PathsTextBoxEnterHandler);
+            this.txtSplitAheadLosing.Leave += new System.EventHandler(this.PathsTextBoxLeaveHandler);
             // 
             // txtSplitAheadGaining
             // 
@@ -648,6 +673,8 @@
             this.txtSplitAheadGaining.ReadOnly = true;
             this.txtSplitAheadGaining.Size = new System.Drawing.Size(134, 20);
             this.txtSplitAheadGaining.TabIndex = 4;
+            this.txtSplitAheadGaining.Enter += new System.EventHandler(this.PathsTextBoxEnterHandler);
+            this.txtSplitAheadGaining.Leave += new System.EventHandler(this.PathsTextBoxLeaveHandler);
             // 
             // txtSplitPath
             // 
@@ -657,6 +684,8 @@
             this.txtSplitPath.ReadOnly = true;
             this.txtSplitPath.Size = new System.Drawing.Size(134, 20);
             this.txtSplitPath.TabIndex = 1;
+            this.txtSplitPath.Enter += new System.EventHandler(this.PathsTextBoxEnterHandler);
+            this.txtSplitPath.Leave += new System.EventHandler(this.PathsTextBoxLeaveHandler);
             // 
             // btnResume
             // 
@@ -1348,6 +1377,7 @@
         private System.Windows.Forms.Label label30;
         private System.Windows.Forms.ComboBox cbOutputDevice;
         private System.Windows.Forms.ToolTip ttVolume;
+        private System.Windows.Forms.ToolTip ttPaths;
         private System.Windows.Forms.Button btnClearStartTimer;
         private System.Windows.Forms.Button btnClearResume;
         private System.Windows.Forms.Button btnClearPause;

--- a/src/LiveSplit.Sound/UI/Components/SoundSettings.Designer.cs
+++ b/src/LiveSplit.Sound/UI/Components/SoundSettings.Designer.cs
@@ -229,6 +229,7 @@
             this.txtStartTimer.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.txtStartTimer.Location = new System.Drawing.Point(149, 381);
             this.txtStartTimer.Name = "txtStartTimer";
+            this.txtStartTimer.ReadOnly = true;
             this.txtStartTimer.Size = new System.Drawing.Size(215, 20);
             this.txtStartTimer.TabIndex = 40;
             // 
@@ -377,6 +378,7 @@
             this.txtResume.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.txtResume.Location = new System.Drawing.Point(149, 352);
             this.txtResume.Name = "txtResume";
+            this.txtResume.ReadOnly = true;
             this.txtResume.Size = new System.Drawing.Size(215, 20);
             this.txtResume.TabIndex = 37;
             // 
@@ -385,6 +387,7 @@
             this.txtPause.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.txtPause.Location = new System.Drawing.Point(149, 323);
             this.txtPause.Name = "txtPause";
+            this.txtPause.ReadOnly = true;
             this.txtPause.Size = new System.Drawing.Size(215, 20);
             this.txtPause.TabIndex = 34;
             // 
@@ -393,6 +396,7 @@
             this.txtReset.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.txtReset.Location = new System.Drawing.Point(149, 294);
             this.txtReset.Name = "txtReset";
+            this.txtReset.ReadOnly = true;
             this.txtReset.Size = new System.Drawing.Size(215, 20);
             this.txtReset.TabIndex = 31;
             // 
@@ -401,6 +405,7 @@
             this.txtNotAPersonalBest.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.txtNotAPersonalBest.Location = new System.Drawing.Point(149, 265);
             this.txtNotAPersonalBest.Name = "txtNotAPersonalBest";
+            this.txtNotAPersonalBest.ReadOnly = true;
             this.txtNotAPersonalBest.Size = new System.Drawing.Size(215, 20);
             this.txtNotAPersonalBest.TabIndex = 28;
             // 
@@ -409,6 +414,7 @@
             this.txtPersonalBest.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.txtPersonalBest.Location = new System.Drawing.Point(149, 236);
             this.txtPersonalBest.Name = "txtPersonalBest";
+            this.txtPersonalBest.ReadOnly = true;
             this.txtPersonalBest.Size = new System.Drawing.Size(215, 20);
             this.txtPersonalBest.TabIndex = 25;
             // 
@@ -417,6 +423,7 @@
             this.txtSkip.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.txtSkip.Location = new System.Drawing.Point(149, 207);
             this.txtSkip.Name = "txtSkip";
+            this.txtSkip.ReadOnly = true;
             this.txtSkip.Size = new System.Drawing.Size(215, 20);
             this.txtSkip.TabIndex = 22;
             // 
@@ -425,6 +432,7 @@
             this.txtUndo.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.txtUndo.Location = new System.Drawing.Point(149, 178);
             this.txtUndo.Name = "txtUndo";
+            this.txtUndo.ReadOnly = true;
             this.txtUndo.Size = new System.Drawing.Size(215, 20);
             this.txtUndo.TabIndex = 19;
             // 
@@ -433,6 +441,7 @@
             this.txtBestSegment.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.txtBestSegment.Location = new System.Drawing.Point(149, 149);
             this.txtBestSegment.Name = "txtBestSegment";
+            this.txtBestSegment.ReadOnly = true;
             this.txtBestSegment.Size = new System.Drawing.Size(215, 20);
             this.txtBestSegment.TabIndex = 16;
             // 
@@ -441,6 +450,7 @@
             this.txtSplitBehindLosing.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.txtSplitBehindLosing.Location = new System.Drawing.Point(149, 120);
             this.txtSplitBehindLosing.Name = "txtSplitBehindLosing";
+            this.txtSplitBehindLosing.ReadOnly = true;
             this.txtSplitBehindLosing.Size = new System.Drawing.Size(215, 20);
             this.txtSplitBehindLosing.TabIndex = 13;
             // 
@@ -449,6 +459,7 @@
             this.txtSplitBehindGaining.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.txtSplitBehindGaining.Location = new System.Drawing.Point(149, 91);
             this.txtSplitBehindGaining.Name = "txtSplitBehindGaining";
+            this.txtSplitBehindGaining.ReadOnly = true;
             this.txtSplitBehindGaining.Size = new System.Drawing.Size(215, 20);
             this.txtSplitBehindGaining.TabIndex = 10;
             // 
@@ -457,6 +468,7 @@
             this.txtSplitAheadLosing.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.txtSplitAheadLosing.Location = new System.Drawing.Point(149, 62);
             this.txtSplitAheadLosing.Name = "txtSplitAheadLosing";
+            this.txtSplitAheadLosing.ReadOnly = true;
             this.txtSplitAheadLosing.Size = new System.Drawing.Size(215, 20);
             this.txtSplitAheadLosing.TabIndex = 7;
             // 
@@ -465,6 +477,7 @@
             this.txtSplitAheadGaining.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.txtSplitAheadGaining.Location = new System.Drawing.Point(149, 33);
             this.txtSplitAheadGaining.Name = "txtSplitAheadGaining";
+            this.txtSplitAheadGaining.ReadOnly = true;
             this.txtSplitAheadGaining.Size = new System.Drawing.Size(215, 20);
             this.txtSplitAheadGaining.TabIndex = 4;
             // 
@@ -473,6 +486,7 @@
             this.txtSplitPath.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.txtSplitPath.Location = new System.Drawing.Point(149, 4);
             this.txtSplitPath.Name = "txtSplitPath";
+            this.txtSplitPath.ReadOnly = true;
             this.txtSplitPath.Size = new System.Drawing.Size(215, 20);
             this.txtSplitPath.TabIndex = 1;
             // 

--- a/src/LiveSplit.Sound/UI/Components/SoundSettings.Designer.cs
+++ b/src/LiveSplit.Sound/UI/Components/SoundSettings.Designer.cs
@@ -32,6 +32,20 @@
             this.tabControl1 = new System.Windows.Forms.TabControl();
             this.tpSoundFiles = new System.Windows.Forms.TabPage();
             this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
+            this.btnClearStartTimer = new System.Windows.Forms.Button();
+            this.btnClearResume = new System.Windows.Forms.Button();
+            this.btnClearPause = new System.Windows.Forms.Button();
+            this.btnClearReset = new System.Windows.Forms.Button();
+            this.btnClearNotAPersonalBest = new System.Windows.Forms.Button();
+            this.btnClearPersonalBest = new System.Windows.Forms.Button();
+            this.btnClearSkip = new System.Windows.Forms.Button();
+            this.btnClearUndo = new System.Windows.Forms.Button();
+            this.btnClearBestSegment = new System.Windows.Forms.Button();
+            this.btnClearSplitBehindLosing = new System.Windows.Forms.Button();
+            this.btnClearSplitBehindGaining = new System.Windows.Forms.Button();
+            this.btnClearSplitAheadLosing = new System.Windows.Forms.Button();
+            this.btnClearSplitAheadGaining = new System.Windows.Forms.Button();
+            this.btnClearSplit = new System.Windows.Forms.Button();
             this.txtStartTimer = new System.Windows.Forms.TextBox();
             this.label14 = new System.Windows.Forms.Label();
             this.label13 = new System.Windows.Forms.Label();
@@ -155,11 +169,25 @@
             // 
             // tableLayoutPanel1
             // 
-            this.tableLayoutPanel1.ColumnCount = 3;
+            this.tableLayoutPanel1.ColumnCount = 4;
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 146F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
-            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel1.Controls.Add(this.btnClearStartTimer, 3, 13);
+            this.tableLayoutPanel1.Controls.Add(this.btnClearResume, 3, 12);
+            this.tableLayoutPanel1.Controls.Add(this.btnClearPause, 3, 11);
+            this.tableLayoutPanel1.Controls.Add(this.btnClearReset, 3, 10);
+            this.tableLayoutPanel1.Controls.Add(this.btnClearNotAPersonalBest, 3, 9);
+            this.tableLayoutPanel1.Controls.Add(this.btnClearPersonalBest, 3, 8);
+            this.tableLayoutPanel1.Controls.Add(this.btnClearSkip, 3, 7);
+            this.tableLayoutPanel1.Controls.Add(this.btnClearUndo, 3, 6);
+            this.tableLayoutPanel1.Controls.Add(this.btnClearBestSegment, 3, 5);
+            this.tableLayoutPanel1.Controls.Add(this.btnClearSplitBehindLosing, 3, 4);
+            this.tableLayoutPanel1.Controls.Add(this.btnClearSplitBehindGaining, 3, 3);
+            this.tableLayoutPanel1.Controls.Add(this.btnClearSplitAheadLosing, 3, 2);
+            this.tableLayoutPanel1.Controls.Add(this.btnClearSplitAheadGaining, 3, 1);
+            this.tableLayoutPanel1.Controls.Add(this.btnClearSplit, 3, 0);
             this.tableLayoutPanel1.Controls.Add(this.txtStartTimer, 1, 13);
             this.tableLayoutPanel1.Controls.Add(this.label14, 0, 13);
             this.tableLayoutPanel1.Controls.Add(this.label13, 0, 12);
@@ -224,13 +252,153 @@
             this.tableLayoutPanel1.Size = new System.Drawing.Size(448, 407);
             this.tableLayoutPanel1.TabIndex = 0;
             // 
+            // btnClearStartTimer
+            // 
+            this.btnClearStartTimer.Location = new System.Drawing.Point(370, 380);
+            this.btnClearStartTimer.Name = "btnClearStartTimer";
+            this.btnClearStartTimer.Size = new System.Drawing.Size(75, 23);
+            this.btnClearStartTimer.TabIndex = 55;
+            this.btnClearStartTimer.Text = "Clear";
+            this.btnClearStartTimer.UseVisualStyleBackColor = true;
+            this.btnClearStartTimer.Click += new System.EventHandler(this.btnClearStartTimer_Click);
+            // 
+            // btnClearResume
+            // 
+            this.btnClearResume.Location = new System.Drawing.Point(370, 351);
+            this.btnClearResume.Name = "btnClearResume";
+            this.btnClearResume.Size = new System.Drawing.Size(75, 23);
+            this.btnClearResume.TabIndex = 54;
+            this.btnClearResume.Text = "Clear";
+            this.btnClearResume.UseVisualStyleBackColor = true;
+            this.btnClearResume.Click += new System.EventHandler(this.btnClearResume_Click);
+            // 
+            // btnClearPause
+            // 
+            this.btnClearPause.Location = new System.Drawing.Point(370, 322);
+            this.btnClearPause.Name = "btnClearPause";
+            this.btnClearPause.Size = new System.Drawing.Size(75, 23);
+            this.btnClearPause.TabIndex = 53;
+            this.btnClearPause.Text = "Clear";
+            this.btnClearPause.UseVisualStyleBackColor = true;
+            this.btnClearPause.Click += new System.EventHandler(this.btnClearPause_Click);
+            // 
+            // btnClearReset
+            // 
+            this.btnClearReset.Location = new System.Drawing.Point(370, 293);
+            this.btnClearReset.Name = "btnClearReset";
+            this.btnClearReset.Size = new System.Drawing.Size(75, 23);
+            this.btnClearReset.TabIndex = 52;
+            this.btnClearReset.Text = "Clear";
+            this.btnClearReset.UseVisualStyleBackColor = true;
+            this.btnClearReset.Click += new System.EventHandler(this.btnClearReset_Click);
+            // 
+            // btnClearNotAPersonalBest
+            // 
+            this.btnClearNotAPersonalBest.Location = new System.Drawing.Point(370, 264);
+            this.btnClearNotAPersonalBest.Name = "btnClearNotAPersonalBest";
+            this.btnClearNotAPersonalBest.Size = new System.Drawing.Size(75, 23);
+            this.btnClearNotAPersonalBest.TabIndex = 51;
+            this.btnClearNotAPersonalBest.Text = "Clear";
+            this.btnClearNotAPersonalBest.UseVisualStyleBackColor = true;
+            this.btnClearNotAPersonalBest.Click += new System.EventHandler(this.btnClearNotAPersonalBest_Click);
+            // 
+            // btnClearPersonalBest
+            // 
+            this.btnClearPersonalBest.Location = new System.Drawing.Point(370, 235);
+            this.btnClearPersonalBest.Name = "btnClearPersonalBest";
+            this.btnClearPersonalBest.Size = new System.Drawing.Size(75, 23);
+            this.btnClearPersonalBest.TabIndex = 50;
+            this.btnClearPersonalBest.Text = "Clear";
+            this.btnClearPersonalBest.UseVisualStyleBackColor = true;
+            this.btnClearPersonalBest.Click += new System.EventHandler(this.btnClearPersonalBest_Click);
+            // 
+            // btnClearSkip
+            // 
+            this.btnClearSkip.Location = new System.Drawing.Point(370, 206);
+            this.btnClearSkip.Name = "btnClearSkip";
+            this.btnClearSkip.Size = new System.Drawing.Size(75, 23);
+            this.btnClearSkip.TabIndex = 49;
+            this.btnClearSkip.Text = "Clear";
+            this.btnClearSkip.UseVisualStyleBackColor = true;
+            this.btnClearSkip.Click += new System.EventHandler(this.btnClearSkipSplit_Click);
+            // 
+            // btnClearUndo
+            // 
+            this.btnClearUndo.Location = new System.Drawing.Point(370, 177);
+            this.btnClearUndo.Name = "btnClearUndo";
+            this.btnClearUndo.Size = new System.Drawing.Size(75, 23);
+            this.btnClearUndo.TabIndex = 48;
+            this.btnClearUndo.Text = "Clear";
+            this.btnClearUndo.UseVisualStyleBackColor = true;
+            this.btnClearUndo.Click += new System.EventHandler(this.btnClearUndo_Click);
+            // 
+            // btnClearBestSegment
+            // 
+            this.btnClearBestSegment.Location = new System.Drawing.Point(370, 148);
+            this.btnClearBestSegment.Name = "btnClearBestSegment";
+            this.btnClearBestSegment.Size = new System.Drawing.Size(75, 23);
+            this.btnClearBestSegment.TabIndex = 47;
+            this.btnClearBestSegment.Text = "Clear";
+            this.btnClearBestSegment.UseVisualStyleBackColor = true;
+            this.btnClearBestSegment.Click += new System.EventHandler(this.btnClearBestSegment_Click);
+            // 
+            // btnClearSplitBehindLosing
+            // 
+            this.btnClearSplitBehindLosing.Location = new System.Drawing.Point(370, 119);
+            this.btnClearSplitBehindLosing.Name = "btnClearSplitBehindLosing";
+            this.btnClearSplitBehindLosing.Size = new System.Drawing.Size(75, 23);
+            this.btnClearSplitBehindLosing.TabIndex = 46;
+            this.btnClearSplitBehindLosing.Text = "Clear";
+            this.btnClearSplitBehindLosing.UseVisualStyleBackColor = true;
+            this.btnClearSplitBehindLosing.Click += new System.EventHandler(this.btnClearBehindLosing_Click);
+            // 
+            // btnClearSplitBehindGaining
+            // 
+            this.btnClearSplitBehindGaining.Location = new System.Drawing.Point(370, 90);
+            this.btnClearSplitBehindGaining.Name = "btnClearSplitBehindGaining";
+            this.btnClearSplitBehindGaining.Size = new System.Drawing.Size(75, 23);
+            this.btnClearSplitBehindGaining.TabIndex = 45;
+            this.btnClearSplitBehindGaining.Text = "Clear";
+            this.btnClearSplitBehindGaining.UseVisualStyleBackColor = true;
+            this.btnClearSplitBehindGaining.Click += new System.EventHandler(this.btnClearBehindGaining_Click);
+            // 
+            // btnClearSplitAheadLosing
+            // 
+            this.btnClearSplitAheadLosing.Location = new System.Drawing.Point(370, 61);
+            this.btnClearSplitAheadLosing.Name = "btnClearSplitAheadLosing";
+            this.btnClearSplitAheadLosing.Size = new System.Drawing.Size(75, 23);
+            this.btnClearSplitAheadLosing.TabIndex = 44;
+            this.btnClearSplitAheadLosing.Text = "Clear";
+            this.btnClearSplitAheadLosing.UseVisualStyleBackColor = true;
+            this.btnClearSplitAheadLosing.Click += new System.EventHandler(this.btnClearAheadLosing_Click);
+            // 
+            // btnClearSplitAheadGaining
+            // 
+            this.btnClearSplitAheadGaining.Location = new System.Drawing.Point(370, 32);
+            this.btnClearSplitAheadGaining.Name = "btnClearSplitAheadGaining";
+            this.btnClearSplitAheadGaining.Size = new System.Drawing.Size(75, 23);
+            this.btnClearSplitAheadGaining.TabIndex = 43;
+            this.btnClearSplitAheadGaining.Text = "Clear";
+            this.btnClearSplitAheadGaining.UseVisualStyleBackColor = true;
+            this.btnClearSplitAheadGaining.Click += new System.EventHandler(this.btnClearAheadGaining_Click);
+            // 
+            // btnClearSplit
+            // 
+            this.btnClearSplit.Location = new System.Drawing.Point(370, 3);
+            this.btnClearSplit.Name = "btnClearSplit";
+            this.btnClearSplit.Size = new System.Drawing.Size(75, 23);
+            this.btnClearSplit.TabIndex = 42;
+            this.btnClearSplit.Text = "Clear";
+            this.btnClearSplit.UseVisualStyleBackColor = true;
+            this.btnClearSplit.Click += new System.EventHandler(this.btnClearSplit_Click);
+            // 
             // txtStartTimer
             // 
             this.txtStartTimer.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.txtStartTimer.Location = new System.Drawing.Point(149, 381);
             this.txtStartTimer.Name = "txtStartTimer";
             this.txtStartTimer.ReadOnly = true;
-            this.txtStartTimer.Size = new System.Drawing.Size(215, 20);
+            this.txtStartTimer.Size = new System.Drawing.Size(134, 20);
             this.txtStartTimer.TabIndex = 40;
             // 
             // label14
@@ -379,7 +547,7 @@
             this.txtResume.Location = new System.Drawing.Point(149, 352);
             this.txtResume.Name = "txtResume";
             this.txtResume.ReadOnly = true;
-            this.txtResume.Size = new System.Drawing.Size(215, 20);
+            this.txtResume.Size = new System.Drawing.Size(134, 20);
             this.txtResume.TabIndex = 37;
             // 
             // txtPause
@@ -388,7 +556,7 @@
             this.txtPause.Location = new System.Drawing.Point(149, 323);
             this.txtPause.Name = "txtPause";
             this.txtPause.ReadOnly = true;
-            this.txtPause.Size = new System.Drawing.Size(215, 20);
+            this.txtPause.Size = new System.Drawing.Size(134, 20);
             this.txtPause.TabIndex = 34;
             // 
             // txtReset
@@ -397,7 +565,7 @@
             this.txtReset.Location = new System.Drawing.Point(149, 294);
             this.txtReset.Name = "txtReset";
             this.txtReset.ReadOnly = true;
-            this.txtReset.Size = new System.Drawing.Size(215, 20);
+            this.txtReset.Size = new System.Drawing.Size(134, 20);
             this.txtReset.TabIndex = 31;
             // 
             // txtNotAPersonalBest
@@ -406,7 +574,7 @@
             this.txtNotAPersonalBest.Location = new System.Drawing.Point(149, 265);
             this.txtNotAPersonalBest.Name = "txtNotAPersonalBest";
             this.txtNotAPersonalBest.ReadOnly = true;
-            this.txtNotAPersonalBest.Size = new System.Drawing.Size(215, 20);
+            this.txtNotAPersonalBest.Size = new System.Drawing.Size(134, 20);
             this.txtNotAPersonalBest.TabIndex = 28;
             // 
             // txtPersonalBest
@@ -415,7 +583,7 @@
             this.txtPersonalBest.Location = new System.Drawing.Point(149, 236);
             this.txtPersonalBest.Name = "txtPersonalBest";
             this.txtPersonalBest.ReadOnly = true;
-            this.txtPersonalBest.Size = new System.Drawing.Size(215, 20);
+            this.txtPersonalBest.Size = new System.Drawing.Size(134, 20);
             this.txtPersonalBest.TabIndex = 25;
             // 
             // txtSkip
@@ -424,7 +592,7 @@
             this.txtSkip.Location = new System.Drawing.Point(149, 207);
             this.txtSkip.Name = "txtSkip";
             this.txtSkip.ReadOnly = true;
-            this.txtSkip.Size = new System.Drawing.Size(215, 20);
+            this.txtSkip.Size = new System.Drawing.Size(134, 20);
             this.txtSkip.TabIndex = 22;
             // 
             // txtUndo
@@ -433,7 +601,7 @@
             this.txtUndo.Location = new System.Drawing.Point(149, 178);
             this.txtUndo.Name = "txtUndo";
             this.txtUndo.ReadOnly = true;
-            this.txtUndo.Size = new System.Drawing.Size(215, 20);
+            this.txtUndo.Size = new System.Drawing.Size(134, 20);
             this.txtUndo.TabIndex = 19;
             // 
             // txtBestSegment
@@ -442,7 +610,7 @@
             this.txtBestSegment.Location = new System.Drawing.Point(149, 149);
             this.txtBestSegment.Name = "txtBestSegment";
             this.txtBestSegment.ReadOnly = true;
-            this.txtBestSegment.Size = new System.Drawing.Size(215, 20);
+            this.txtBestSegment.Size = new System.Drawing.Size(134, 20);
             this.txtBestSegment.TabIndex = 16;
             // 
             // txtSplitBehindLosing
@@ -451,7 +619,7 @@
             this.txtSplitBehindLosing.Location = new System.Drawing.Point(149, 120);
             this.txtSplitBehindLosing.Name = "txtSplitBehindLosing";
             this.txtSplitBehindLosing.ReadOnly = true;
-            this.txtSplitBehindLosing.Size = new System.Drawing.Size(215, 20);
+            this.txtSplitBehindLosing.Size = new System.Drawing.Size(134, 20);
             this.txtSplitBehindLosing.TabIndex = 13;
             // 
             // txtSplitBehindGaining
@@ -460,7 +628,7 @@
             this.txtSplitBehindGaining.Location = new System.Drawing.Point(149, 91);
             this.txtSplitBehindGaining.Name = "txtSplitBehindGaining";
             this.txtSplitBehindGaining.ReadOnly = true;
-            this.txtSplitBehindGaining.Size = new System.Drawing.Size(215, 20);
+            this.txtSplitBehindGaining.Size = new System.Drawing.Size(134, 20);
             this.txtSplitBehindGaining.TabIndex = 10;
             // 
             // txtSplitAheadLosing
@@ -469,7 +637,7 @@
             this.txtSplitAheadLosing.Location = new System.Drawing.Point(149, 62);
             this.txtSplitAheadLosing.Name = "txtSplitAheadLosing";
             this.txtSplitAheadLosing.ReadOnly = true;
-            this.txtSplitAheadLosing.Size = new System.Drawing.Size(215, 20);
+            this.txtSplitAheadLosing.Size = new System.Drawing.Size(134, 20);
             this.txtSplitAheadLosing.TabIndex = 7;
             // 
             // txtSplitAheadGaining
@@ -478,7 +646,7 @@
             this.txtSplitAheadGaining.Location = new System.Drawing.Point(149, 33);
             this.txtSplitAheadGaining.Name = "txtSplitAheadGaining";
             this.txtSplitAheadGaining.ReadOnly = true;
-            this.txtSplitAheadGaining.Size = new System.Drawing.Size(215, 20);
+            this.txtSplitAheadGaining.Size = new System.Drawing.Size(134, 20);
             this.txtSplitAheadGaining.TabIndex = 4;
             // 
             // txtSplitPath
@@ -487,12 +655,12 @@
             this.txtSplitPath.Location = new System.Drawing.Point(149, 4);
             this.txtSplitPath.Name = "txtSplitPath";
             this.txtSplitPath.ReadOnly = true;
-            this.txtSplitPath.Size = new System.Drawing.Size(215, 20);
+            this.txtSplitPath.Size = new System.Drawing.Size(134, 20);
             this.txtSplitPath.TabIndex = 1;
             // 
             // btnResume
             // 
-            this.btnResume.Location = new System.Drawing.Point(370, 351);
+            this.btnResume.Location = new System.Drawing.Point(289, 351);
             this.btnResume.Name = "btnResume";
             this.btnResume.Size = new System.Drawing.Size(75, 23);
             this.btnResume.TabIndex = 38;
@@ -502,7 +670,7 @@
             // 
             // btnPause
             // 
-            this.btnPause.Location = new System.Drawing.Point(370, 322);
+            this.btnPause.Location = new System.Drawing.Point(289, 322);
             this.btnPause.Name = "btnPause";
             this.btnPause.Size = new System.Drawing.Size(75, 23);
             this.btnPause.TabIndex = 35;
@@ -512,7 +680,7 @@
             // 
             // btnReset
             // 
-            this.btnReset.Location = new System.Drawing.Point(370, 293);
+            this.btnReset.Location = new System.Drawing.Point(289, 293);
             this.btnReset.Name = "btnReset";
             this.btnReset.Size = new System.Drawing.Size(75, 23);
             this.btnReset.TabIndex = 32;
@@ -522,7 +690,7 @@
             // 
             // btnNotAPersonalBest
             // 
-            this.btnNotAPersonalBest.Location = new System.Drawing.Point(370, 264);
+            this.btnNotAPersonalBest.Location = new System.Drawing.Point(289, 264);
             this.btnNotAPersonalBest.Name = "btnNotAPersonalBest";
             this.btnNotAPersonalBest.Size = new System.Drawing.Size(75, 23);
             this.btnNotAPersonalBest.TabIndex = 29;
@@ -532,7 +700,7 @@
             // 
             // btnPersonalBest
             // 
-            this.btnPersonalBest.Location = new System.Drawing.Point(370, 235);
+            this.btnPersonalBest.Location = new System.Drawing.Point(289, 235);
             this.btnPersonalBest.Name = "btnPersonalBest";
             this.btnPersonalBest.Size = new System.Drawing.Size(75, 23);
             this.btnPersonalBest.TabIndex = 26;
@@ -542,7 +710,7 @@
             // 
             // btnSkipSplit
             // 
-            this.btnSkipSplit.Location = new System.Drawing.Point(370, 206);
+            this.btnSkipSplit.Location = new System.Drawing.Point(289, 206);
             this.btnSkipSplit.Name = "btnSkipSplit";
             this.btnSkipSplit.Size = new System.Drawing.Size(75, 23);
             this.btnSkipSplit.TabIndex = 23;
@@ -552,7 +720,7 @@
             // 
             // btnUndo
             // 
-            this.btnUndo.Location = new System.Drawing.Point(370, 177);
+            this.btnUndo.Location = new System.Drawing.Point(289, 177);
             this.btnUndo.Name = "btnUndo";
             this.btnUndo.Size = new System.Drawing.Size(75, 23);
             this.btnUndo.TabIndex = 20;
@@ -562,7 +730,7 @@
             // 
             // btnBestSegment
             // 
-            this.btnBestSegment.Location = new System.Drawing.Point(370, 148);
+            this.btnBestSegment.Location = new System.Drawing.Point(289, 148);
             this.btnBestSegment.Name = "btnBestSegment";
             this.btnBestSegment.Size = new System.Drawing.Size(75, 23);
             this.btnBestSegment.TabIndex = 17;
@@ -572,7 +740,7 @@
             // 
             // btnBehindLosing
             // 
-            this.btnBehindLosing.Location = new System.Drawing.Point(370, 119);
+            this.btnBehindLosing.Location = new System.Drawing.Point(289, 119);
             this.btnBehindLosing.Name = "btnBehindLosing";
             this.btnBehindLosing.Size = new System.Drawing.Size(75, 23);
             this.btnBehindLosing.TabIndex = 14;
@@ -582,7 +750,7 @@
             // 
             // btnBehindGaining
             // 
-            this.btnBehindGaining.Location = new System.Drawing.Point(370, 90);
+            this.btnBehindGaining.Location = new System.Drawing.Point(289, 90);
             this.btnBehindGaining.Name = "btnBehindGaining";
             this.btnBehindGaining.Size = new System.Drawing.Size(75, 23);
             this.btnBehindGaining.TabIndex = 11;
@@ -592,7 +760,7 @@
             // 
             // btnAheadLosing
             // 
-            this.btnAheadLosing.Location = new System.Drawing.Point(370, 61);
+            this.btnAheadLosing.Location = new System.Drawing.Point(289, 61);
             this.btnAheadLosing.Name = "btnAheadLosing";
             this.btnAheadLosing.Size = new System.Drawing.Size(75, 23);
             this.btnAheadLosing.TabIndex = 8;
@@ -602,7 +770,7 @@
             // 
             // btnAheadGaining
             // 
-            this.btnAheadGaining.Location = new System.Drawing.Point(370, 32);
+            this.btnAheadGaining.Location = new System.Drawing.Point(289, 32);
             this.btnAheadGaining.Name = "btnAheadGaining";
             this.btnAheadGaining.Size = new System.Drawing.Size(75, 23);
             this.btnAheadGaining.TabIndex = 5;
@@ -612,7 +780,7 @@
             // 
             // btnSplit
             // 
-            this.btnSplit.Location = new System.Drawing.Point(370, 3);
+            this.btnSplit.Location = new System.Drawing.Point(289, 3);
             this.btnSplit.Name = "btnSplit";
             this.btnSplit.Size = new System.Drawing.Size(75, 23);
             this.btnSplit.TabIndex = 2;
@@ -622,7 +790,7 @@
             // 
             // btnStartTimer
             // 
-            this.btnStartTimer.Location = new System.Drawing.Point(370, 380);
+            this.btnStartTimer.Location = new System.Drawing.Point(289, 380);
             this.btnStartTimer.Name = "btnStartTimer";
             this.btnStartTimer.Size = new System.Drawing.Size(75, 23);
             this.btnStartTimer.TabIndex = 41;
@@ -1180,6 +1348,19 @@
         private System.Windows.Forms.Label label30;
         private System.Windows.Forms.ComboBox cbOutputDevice;
         private System.Windows.Forms.ToolTip ttVolume;
-
+        private System.Windows.Forms.Button btnClearStartTimer;
+        private System.Windows.Forms.Button btnClearResume;
+        private System.Windows.Forms.Button btnClearPause;
+        private System.Windows.Forms.Button btnClearReset;
+        private System.Windows.Forms.Button btnClearNotAPersonalBest;
+        private System.Windows.Forms.Button btnClearPersonalBest;
+        private System.Windows.Forms.Button btnClearSkip;
+        private System.Windows.Forms.Button btnClearUndo;
+        private System.Windows.Forms.Button btnClearBestSegment;
+        private System.Windows.Forms.Button btnClearSplitBehindLosing;
+        private System.Windows.Forms.Button btnClearSplitBehindGaining;
+        private System.Windows.Forms.Button btnClearSplitAheadLosing;
+        private System.Windows.Forms.Button btnClearSplitAheadGaining;
+        private System.Windows.Forms.Button btnClearSplit;
     }
 }

--- a/src/LiveSplit.Sound/UI/Components/SoundSettings.cs
+++ b/src/LiveSplit.Sound/UI/Components/SoundSettings.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Windows.Forms;
 using System.Xml;
 
@@ -8,20 +10,20 @@ namespace LiveSplit.UI.Components;
 
 public partial class SoundSettings : UserControl
 {
-    public string Split { get; set; }
-    public string SplitAheadGaining { get; set; }
-    public string SplitAheadLosing { get; set; }
-    public string SplitBehindGaining { get; set; }
-    public string SplitBehindLosing { get; set; }
-    public string BestSegment { get; set; }
-    public string UndoSplit { get; set; }
-    public string SkipSplit { get; set; }
-    public string PersonalBest { get; set; }
-    public string NotAPersonalBest { get; set; }
-    public string Reset { get; set; }
-    public string Pause { get; set; }
-    public string Resume { get; set; }
-    public string StartTimer { get; set; }
+    public IList<string> Split { get; set; }
+    public IList<string> SplitAheadGaining { get; set; }
+    public IList<string> SplitAheadLosing { get; set; }
+    public IList<string> SplitBehindGaining { get; set; }
+    public IList<string> SplitBehindLosing { get; set; }
+    public IList<string> BestSegment { get; set; }
+    public IList<string> UndoSplit { get; set; }
+    public IList<string> SkipSplit { get; set; }
+    public IList<string> PersonalBest { get; set; }
+    public IList<string> NotAPersonalBest { get; set; }
+    public IList<string> Reset { get; set; }
+    public IList<string> Pause { get; set; }
+    public IList<string> Resume { get; set; }
+    public IList<string> StartTimer { get; set; }
 
     public int OutputDevice { get; set; }
 
@@ -45,20 +47,20 @@ public partial class SoundSettings : UserControl
     {
         InitializeComponent();
 
-        Split =
-        SplitAheadGaining =
-        SplitAheadLosing =
-        SplitBehindGaining =
-        SplitBehindLosing =
-        BestSegment =
-        UndoSplit =
-        SkipSplit =
-        PersonalBest =
-        NotAPersonalBest =
-        Reset =
-        Pause =
-        Resume =
-        StartTimer = "";
+        Split = [];
+        SplitAheadGaining = [];
+        SplitAheadLosing = [];
+        SplitBehindGaining = [];
+        SplitBehindLosing = [];
+        BestSegment = [];
+        UndoSplit = [];
+        SkipSplit = [];
+        PersonalBest = [];
+        NotAPersonalBest = [];
+        Reset = [];
+        Pause = [];
+        Resume = [];
+        StartTimer = [];
 
         OutputDevice = 0;
 
@@ -83,20 +85,20 @@ public partial class SoundSettings : UserControl
             cbOutputDevice.Items.Add(WaveOut.GetCapabilities(i));
         }
 
-        txtSplitPath.DataBindings.Add("Text", this, "Split");
-        txtSplitAheadGaining.DataBindings.Add("Text", this, "SplitAheadGaining");
-        txtSplitAheadLosing.DataBindings.Add("Text", this, "SplitAheadLosing");
-        txtSplitBehindGaining.DataBindings.Add("Text", this, "SplitBehindGaining");
-        txtSplitBehindLosing.DataBindings.Add("Text", this, "SplitBehindLosing");
-        txtBestSegment.DataBindings.Add("Text", this, "BestSegment");
-        txtUndo.DataBindings.Add("Text", this, "UndoSplit");
-        txtSkip.DataBindings.Add("Text", this, "SkipSplit");
-        txtPersonalBest.DataBindings.Add("Text", this, "PersonalBest");
-        txtNotAPersonalBest.DataBindings.Add("Text", this, "NotAPersonalBest");
-        txtReset.DataBindings.Add("Text", this, "Reset");
-        txtPause.DataBindings.Add("Text", this, "Pause");
-        txtResume.DataBindings.Add("Text", this, "Resume");
-        txtStartTimer.DataBindings.Add("Text", this, "StartTimer");
+        AddPathListBinding(txtSplitPath.DataBindings, "Text", this, "Split");
+        AddPathListBinding(txtSplitAheadGaining.DataBindings, "Text", this, "SplitAheadGaining");
+        AddPathListBinding(txtSplitAheadLosing.DataBindings, "Text", this, "SplitAheadLosing");
+        AddPathListBinding(txtSplitBehindGaining.DataBindings, "Text", this, "SplitBehindGaining");
+        AddPathListBinding(txtSplitBehindLosing.DataBindings, "Text", this, "SplitBehindLosing");
+        AddPathListBinding(txtBestSegment.DataBindings, "Text", this, "BestSegment");
+        AddPathListBinding(txtUndo.DataBindings, "Text", this, "UndoSplit");
+        AddPathListBinding(txtSkip.DataBindings, "Text", this, "SkipSplit");
+        AddPathListBinding(txtPersonalBest.DataBindings, "Text", this, "PersonalBest");
+        AddPathListBinding(txtNotAPersonalBest.DataBindings, "Text", this, "NotAPersonalBest");
+        AddPathListBinding(txtReset.DataBindings, "Text", this, "Reset");
+        AddPathListBinding(txtPause.DataBindings, "Text", this, "Pause");
+        AddPathListBinding(txtResume.DataBindings, "Text", this, "Resume");
+        AddPathListBinding(txtStartTimer.DataBindings, "Text", this, "StartTimer");
 
         cbOutputDevice.DataBindings.Add("SelectedIndex", this, "OutputDevice");
 
@@ -117,24 +119,40 @@ public partial class SoundSettings : UserControl
         tbStartTimerVolume.DataBindings.Add("Value", this, "StartTimerVolume");
     }
 
+    private void AddPathListBinding(ControlBindingsCollection bindings, string propertyName, object dataSource, string dataMember)
+    {
+        Binding b = new(propertyName, dataSource, dataMember, true, DataSourceUpdateMode.Never);
+        b.Format += new ConvertEventHandler((sender, convertEvent) =>
+        {
+            if (convertEvent.DesiredType != typeof(string))
+            {
+                return;
+            }
+
+            convertEvent.Value = string.Join(", ", (IList<string>)convertEvent.Value);
+        });
+
+        bindings.Add(b);
+    }
+
     public void SetSettings(XmlNode node)
     {
         var element = (XmlElement)node;
 
-        Split = SettingsHelper.ParseString(element["Split"]);
-        SplitAheadGaining = SettingsHelper.ParseString(element["SplitAheadGaining"]);
-        SplitAheadLosing = SettingsHelper.ParseString(element["SplitAheadLosing"]);
-        SplitBehindGaining = SettingsHelper.ParseString(element["SplitBehindGaining"]);
-        SplitBehindLosing = SettingsHelper.ParseString(element["SplitBehindLosing"]);
-        BestSegment = SettingsHelper.ParseString(element["BestSegment"]);
-        UndoSplit = SettingsHelper.ParseString(element["UndoSplit"]);
-        SkipSplit = SettingsHelper.ParseString(element["SkipSplit"]);
-        PersonalBest = SettingsHelper.ParseString(element["PersonalBest"]);
-        NotAPersonalBest = SettingsHelper.ParseString(element["NotAPersonalBest"]);
-        Reset = SettingsHelper.ParseString(element["Reset"]);
-        Pause = SettingsHelper.ParseString(element["Pause"]);
-        Resume = SettingsHelper.ParseString(element["Resume"]);
-        StartTimer = SettingsHelper.ParseString(element["StartTimer"]);
+        Split = ParsePathListSetting(element, "Split");
+        SplitAheadGaining = ParsePathListSetting(element, "SplitAheadGaining");
+        SplitAheadLosing = ParsePathListSetting(element, "SplitAheadLosing");
+        SplitBehindGaining = ParsePathListSetting(element, "SplitBehindGaining");
+        SplitBehindLosing = ParsePathListSetting(element, "SplitBehindLosing");
+        BestSegment = ParsePathListSetting(element, "BestSegment");
+        UndoSplit = ParsePathListSetting(element, "UndoSplit");
+        SkipSplit = ParsePathListSetting(element, "SkipSplit");
+        PersonalBest = ParsePathListSetting(element, "PersonalBest");
+        NotAPersonalBest = ParsePathListSetting(element, "NotAPersonalBest");
+        Reset = ParsePathListSetting(element, "Reset");
+        Pause = ParsePathListSetting(element, "Pause");
+        Resume = ParsePathListSetting(element, "Resume");
+        StartTimer = ParsePathListSetting(element, "StartTimer");
 
         OutputDevice = SettingsHelper.ParseInt(element["OutputDevice"]);
 
@@ -155,6 +173,37 @@ public partial class SoundSettings : UserControl
         GeneralVolume = SettingsHelper.ParseInt(element["GeneralVolume"], 100);
     }
 
+    private IList<string> ParsePathListSetting(XmlElement element, string settingName)
+    {
+        XmlElement settingElement = element[settingName];
+        if (settingElement == null)
+        {
+            return [];
+        }
+
+        IList<string> paths = [];
+
+        XmlNodeList pathTexts = settingElement.SelectNodes("./path/text()");
+        foreach (XmlCharacterData pathData in pathTexts)
+        {
+            if (pathData is XmlText pathText)
+            {
+                paths.Add(pathData.Data);
+            }
+        }
+
+        // Support old, single-path setting format
+        if (paths.Count == 0)
+        {
+            if (settingElement.SelectSingleNode("./text()") is XmlText oldSettingValue)
+            {
+                paths.Add(oldSettingValue.Data);
+            }
+        }
+
+        return paths;
+    }
+
     public XmlNode GetSettings(XmlDocument document)
     {
         XmlElement parent = document.CreateElement("Settings");
@@ -170,20 +219,20 @@ public partial class SoundSettings : UserControl
     private int CreateSettingsNode(XmlDocument document, XmlElement parent)
     {
         return SettingsHelper.CreateSetting(document, parent, "Version", "1.6") ^
-        SettingsHelper.CreateSetting(document, parent, "Split", Split) ^
-        SettingsHelper.CreateSetting(document, parent, "SplitAheadGaining", SplitAheadGaining) ^
-        SettingsHelper.CreateSetting(document, parent, "SplitAheadLosing", SplitAheadLosing) ^
-        SettingsHelper.CreateSetting(document, parent, "SplitBehindGaining", SplitBehindGaining) ^
-        SettingsHelper.CreateSetting(document, parent, "SplitBehindLosing", SplitBehindLosing) ^
-        SettingsHelper.CreateSetting(document, parent, "BestSegment", BestSegment) ^
-        SettingsHelper.CreateSetting(document, parent, "UndoSplit", UndoSplit) ^
-        SettingsHelper.CreateSetting(document, parent, "SkipSplit", SkipSplit) ^
-        SettingsHelper.CreateSetting(document, parent, "PersonalBest", PersonalBest) ^
-        SettingsHelper.CreateSetting(document, parent, "NotAPersonalBest", NotAPersonalBest) ^
-        SettingsHelper.CreateSetting(document, parent, "Reset", Reset) ^
-        SettingsHelper.CreateSetting(document, parent, "Pause", Pause) ^
-        SettingsHelper.CreateSetting(document, parent, "Resume", Resume) ^
-        SettingsHelper.CreateSetting(document, parent, "StartTimer", StartTimer) ^
+        CreatePathListSetting(document, parent, "Split", Split) ^
+        CreatePathListSetting(document, parent, "SplitAheadGaining", SplitAheadGaining) ^
+        CreatePathListSetting(document, parent, "SplitAheadLosing", SplitAheadLosing) ^
+        CreatePathListSetting(document, parent, "SplitBehindGaining", SplitBehindGaining) ^
+        CreatePathListSetting(document, parent, "SplitBehindLosing", SplitBehindLosing) ^
+        CreatePathListSetting(document, parent, "BestSegment", BestSegment) ^
+        CreatePathListSetting(document, parent, "UndoSplit", UndoSplit) ^
+        CreatePathListSetting(document, parent, "SkipSplit", SkipSplit) ^
+        CreatePathListSetting(document, parent, "PersonalBest", PersonalBest) ^
+        CreatePathListSetting(document, parent, "NotAPersonalBest", NotAPersonalBest) ^
+        CreatePathListSetting(document, parent, "Reset", Reset) ^
+        CreatePathListSetting(document, parent, "Pause", Pause) ^
+        CreatePathListSetting(document, parent, "Resume", Resume) ^
+        CreatePathListSetting(document, parent, "StartTimer", StartTimer) ^
         SettingsHelper.CreateSetting(document, parent, "OutputDevice", OutputDevice) ^
         SettingsHelper.CreateSetting(document, parent, "SplitVolume", SplitVolume) ^
         SettingsHelper.CreateSetting(document, parent, "SplitAheadGainingVolume", SplitAheadGainingVolume) ^
@@ -202,97 +251,110 @@ public partial class SoundSettings : UserControl
         SettingsHelper.CreateSetting(document, parent, "GeneralVolume", GeneralVolume);
     }
 
-    protected string BrowseForPath(TextBox textBox, Action<string> callback)
+    private static int CreatePathListSetting(XmlDocument document, XmlElement parent, string name, IList<string> paths)
     {
-        string path = textBox.Text;
+        if (document != null)
+        {
+            XmlElement pathListElement = document.CreateElement(name);
+            foreach (string path in paths)
+            {
+                SettingsHelper.CreateSetting(document, pathListElement, "path", path);
+            }
+
+            parent.AppendChild(pathListElement);
+        }
+
+        return paths.Aggregate(0, (hash, next) => hash ^= next.GetHashCode());
+    }
+
+    private void BrowseForPaths(TextBox textBox, IList<string> paths, Action<IList<string>> callback)
+    {
+        string path = paths.FirstOrDefault() ?? string.Empty;
         var fileDialog = new OpenFileDialog()
         {
             Multiselect = true,
-            FileName = path.Split(';')[0],
+            FileName = path,
             Filter = "Audio Files|*.mp3;*.wav;*.aiff;*.wma|All Files|*.*"
         };
 
         DialogResult result = fileDialog.ShowDialog();
-
         if (result == DialogResult.OK)
         {
-            path = string.Join(";", fileDialog.FileNames);
+            paths = fileDialog.FileNames;
         }
 
-        textBox.Text = path;
-        callback(path);
-
-        return path;
+        textBox.Text = string.Join(", ", paths);
+        callback(paths);
     }
 
     private void btnSplit_Click(object sender, EventArgs e)
     {
-        BrowseForPath(txtSplitPath, (x) => Split = x);
+        BrowseForPaths(txtSplitPath, Split, paths => Split = paths);
     }
 
     private void btnAheadGaining_Click(object sender, EventArgs e)
     {
-        BrowseForPath(txtSplitAheadGaining, (x) => SplitAheadGaining = x);
+        BrowseForPaths(txtSplitAheadGaining, SplitAheadGaining, paths => SplitAheadGaining = paths);
     }
 
     private void btnAheadLosing_Click(object sender, EventArgs e)
     {
-        BrowseForPath(txtSplitAheadLosing, (x) => SplitAheadLosing = x);
+        BrowseForPaths(txtSplitAheadLosing, SplitAheadLosing, paths => SplitAheadLosing = paths);
     }
 
     private void btnBehindGaining_Click(object sender, EventArgs e)
     {
-        BrowseForPath(txtSplitBehindGaining, (x) => SplitBehindGaining = x);
+        BrowseForPaths(txtSplitBehindGaining, SplitBehindGaining, paths => SplitBehindGaining = paths);
     }
 
     private void btnBehindLosing_Click(object sender, EventArgs e)
     {
-        BrowseForPath(txtSplitBehindLosing, (x) => SplitBehindLosing = x);
+        BrowseForPaths(txtSplitBehindLosing, SplitBehindLosing, paths => SplitBehindLosing = paths);
     }
 
     private void btnBestSegment_Click(object sender, EventArgs e)
     {
-        BrowseForPath(txtBestSegment, (x) => BestSegment = x);
+        BrowseForPaths(txtBestSegment, BestSegment, paths => BestSegment = paths);
     }
 
     private void btnUndo_Click(object sender, EventArgs e)
     {
-        BrowseForPath(txtUndo, (x) => UndoSplit = x);
+        BrowseForPaths(txtUndo, UndoSplit, paths => UndoSplit = paths);
     }
 
     private void btnSkipSplit_Click(object sender, EventArgs e)
     {
-        BrowseForPath(txtSkip, (x) => SkipSplit = x);
+        BrowseForPaths(txtSkip, SkipSplit, paths => SkipSplit = paths);
     }
 
     private void btnPersonalBest_Click(object sender, EventArgs e)
     {
-        BrowseForPath(txtPersonalBest, (x) => PersonalBest = x);
+        BrowseForPaths(txtPersonalBest, PersonalBest, paths => PersonalBest = paths);
     }
 
     private void btnNotAPersonalBest_Click(object sender, EventArgs e)
     {
-        BrowseForPath(txtNotAPersonalBest, (x) => NotAPersonalBest = x);
+        BrowseForPaths(txtNotAPersonalBest, NotAPersonalBest, paths => NotAPersonalBest = paths);
     }
 
     private void btnReset_Click(object sender, EventArgs e)
     {
-        BrowseForPath(txtReset, (x) => Reset = x);
+        BrowseForPaths(txtReset, Reset, paths => Reset = paths);
     }
 
     private void btnPause_Click(object sender, EventArgs e)
     {
-        BrowseForPath(txtPause, (x) => Pause = x);
+        BrowseForPaths(txtPause, Pause, paths => Pause = paths);
     }
 
     private void btnResume_Click(object sender, EventArgs e)
     {
-        BrowseForPath(txtResume, (x) => Resume = x);
+        BrowseForPaths(txtResume, Resume, paths => Resume = paths);
     }
 
     private void btnStartTimer_Click(object sender, EventArgs e)
     {
-        BrowseForPath(txtStartTimer, (x) => StartTimer = x);
+        BrowseForPaths(txtStartTimer, StartTimer, paths => StartTimer = paths);
     }
 
     private void VolumeTrackBarScrollHandler(object sender, EventArgs e)

--- a/src/LiveSplit.Sound/UI/Components/SoundSettings.cs
+++ b/src/LiveSplit.Sound/UI/Components/SoundSettings.cs
@@ -207,7 +207,8 @@ public partial class SoundSettings : UserControl
         string path = textBox.Text;
         var fileDialog = new OpenFileDialog()
         {
-            FileName = path,
+            Multiselect = true,
+            FileName = path.Split(';')[0],
             Filter = "Audio Files|*.mp3;*.wav;*.aiff;*.wma|All Files|*.*"
         };
 
@@ -215,7 +216,7 @@ public partial class SoundSettings : UserControl
 
         if (result == DialogResult.OK)
         {
-            path = fileDialog.FileName;
+            path = string.Join(";", fileDialog.FileNames);
         }
 
         textBox.Text = path;

--- a/src/LiveSplit.Sound/UI/Components/SoundSettings.cs
+++ b/src/LiveSplit.Sound/UI/Components/SoundSettings.cs
@@ -10,6 +10,8 @@ namespace LiveSplit.UI.Components;
 
 public partial class SoundSettings : UserControl
 {
+    private const string PathSeparator = ", ";
+
     public IList<string> Split { get; set; }
     public IList<string> SplitAheadGaining { get; set; }
     public IList<string> SplitAheadLosing { get; set; }
@@ -129,7 +131,7 @@ public partial class SoundSettings : UserControl
                 return;
             }
 
-            convertEvent.Value = string.Join(", ", (IList<string>)convertEvent.Value);
+            convertEvent.Value = string.Join(PathSeparator, (IList<string>)convertEvent.Value);
         });
 
         bindings.Add(b);
@@ -283,7 +285,7 @@ public partial class SoundSettings : UserControl
             paths = fileDialog.FileNames;
         }
 
-        textBox.Text = string.Join(", ", paths);
+        textBox.Text = string.Join(PathSeparator, paths);
         callback(paths);
     }
 
@@ -439,6 +441,21 @@ public partial class SoundSettings : UserControl
     {
         StartTimer = [];
         txtStartTimer.Clear();
+    }
+
+    private void PathsTextBoxEnterHandler(object sender, EventArgs e)
+    {
+        var textBox = (TextBox)sender;
+
+        // Display below the text box
+        ttPaths.Show(textBox.Text.Replace(PathSeparator, "\n"), textBox, 0, textBox.Height);
+    }
+
+    private void PathsTextBoxLeaveHandler(object sender, EventArgs e)
+    {
+        var textBox = (TextBox)sender;
+
+        ttPaths.Hide(textBox);
     }
 
     private void VolumeTrackBarScrollHandler(object sender, EventArgs e)

--- a/src/LiveSplit.Sound/UI/Components/SoundSettings.cs
+++ b/src/LiveSplit.Sound/UI/Components/SoundSettings.cs
@@ -357,6 +357,90 @@ public partial class SoundSettings : UserControl
         BrowseForPaths(txtStartTimer, StartTimer, paths => StartTimer = paths);
     }
 
+    private void btnClearSplit_Click(object sender, EventArgs e)
+    {
+        Split = [];
+        txtSplitPath.Clear();
+    }
+
+    private void btnClearAheadGaining_Click(object sender, EventArgs e)
+    {
+        SplitAheadGaining = [];
+        txtSplitAheadGaining.Clear();
+    }
+
+    private void btnClearAheadLosing_Click(object sender, EventArgs e)
+    {
+        SplitAheadLosing = [];
+        txtSplitAheadLosing.Clear();
+    }
+
+    private void btnClearBehindGaining_Click(object sender, EventArgs e)
+    {
+        SplitBehindGaining = [];
+        txtSplitBehindGaining.Clear();
+    }
+
+    private void btnClearBehindLosing_Click(object sender, EventArgs e)
+    {
+        SplitBehindLosing = [];
+        txtSplitBehindLosing.Clear();
+    }
+
+    private void btnClearBestSegment_Click(object sender, EventArgs e)
+    {
+        BestSegment = [];
+        txtBestSegment.Clear();
+    }
+
+    private void btnClearUndo_Click(object sender, EventArgs e)
+    {
+        UndoSplit = [];
+        txtUndo.Clear();
+    }
+
+    private void btnClearSkipSplit_Click(object sender, EventArgs e)
+    {
+        SkipSplit = [];
+        txtSkip.Clear();
+    }
+
+    private void btnClearPersonalBest_Click(object sender, EventArgs e)
+    {
+        PersonalBest = [];
+        txtPersonalBest.Clear();
+    }
+
+    private void btnClearNotAPersonalBest_Click(object sender, EventArgs e)
+    {
+        NotAPersonalBest = [];
+        txtNotAPersonalBest.Clear();
+    }
+
+    private void btnClearReset_Click(object sender, EventArgs e)
+    {
+        Reset = [];
+        txtReset.Clear();
+    }
+
+    private void btnClearPause_Click(object sender, EventArgs e)
+    {
+        Pause = [];
+        txtPause.Clear();
+    }
+
+    private void btnClearResume_Click(object sender, EventArgs e)
+    {
+        Resume = [];
+        txtResume.Clear();
+    }
+
+    private void btnClearStartTimer_Click(object sender, EventArgs e)
+    {
+        StartTimer = [];
+        txtStartTimer.Clear();
+    }
+
     private void VolumeTrackBarScrollHandler(object sender, EventArgs e)
     {
         var trackBar = (TrackBar)sender;

--- a/src/LiveSplit.Sound/UI/Components/SoundSettings.resx
+++ b/src/LiveSplit.Sound/UI/Components/SoundSettings.resx
@@ -120,4 +120,7 @@
   <metadata name="ttVolume.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="ttPaths.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>119, 17</value>
+  </metadata>
 </root>


### PR DESCRIPTION
This is based on and incorporates #5, but changes the settings structure
to use a list of `<path>` tags in order to support arbitrary characters
in the paths. The existing settings format is still understood, and the
next time layouts are saved, they will be saved using the new structure.

The UI is changed in a few ways:
* The text boxes displaying the selected paths are made read-only, as
  they are no longer directly editable. This is because parsing a list
  of paths from the string has the same issue as using a semicolon to
  separate the selected paths: any character is a legal path character,
  even if Windows doesn't allow you to create such paths easily.
* A "Clear" button has been added for each path setting, as making the
  text boxes read-only means the settings can't be cleared by deleting
  the text.
* A tooltip has been added to display the full list of paths. It is
  displayed when entering/selecting one of the path text boxes.